### PR TITLE
Add declarative @option annotation for CLI flags

### DIFF
--- a/app/Commands/RunCommand.php
+++ b/app/Commands/RunCommand.php
@@ -5,9 +5,14 @@ namespace App\Commands;
 use App\Commands\Concerns\ResolvesScottyFile;
 use App\Execution\Executor;
 use App\Execution\TaskResult;
+use App\Parsing\BashParser;
+use App\Parsing\OptionDefinition;
 use App\Parsing\ParseResult;
 use App\Parsing\TaskDefinition;
 use LaravelZero\Framework\Commands\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 
 use function Laravel\Prompts\confirm;
@@ -68,17 +73,37 @@ class RunCommand extends Command
 
     protected ?int $cachedTerminalWidth = null;
 
+    protected ?ParseResult $preloadedConfig = null;
+
+    protected ?string $preloadedFilePath = null;
+
+    public function run(InputInterface $input, OutputInterface $output): int
+    {
+        $this->registerDeclaredOptions($input);
+
+        return parent::run($input, $output);
+    }
+
     public function handle(): int
     {
-        $filePath = $this->resolveFilePathOrFail();
+        $filePath = $this->preloadedFilePath ?? $this->resolveFilePathOrFail();
 
         if ($filePath === null) {
             return 1;
         }
 
         $parser = $this->resolveParser($filePath);
-        $dynamicOptions = $this->gatherDynamicOptions();
-        $config = $parser->parse($filePath, $dynamicOptions);
+        $config = $this->preloadedConfig ?? $parser->parse($filePath);
+
+        $dynamicOptions = $this->resolveDeclaredOptions($config->options);
+
+        if ($dynamicOptions === null) {
+            return 1;
+        }
+
+        if ($this->preloadedConfig === null) {
+            $config = $parser->parse($filePath, $dynamicOptions);
+        }
 
         $target = $this->argument('task');
         $tasks = $config->resolveTasksForTarget($target);
@@ -556,31 +581,111 @@ class RunCommand extends Command
         return preg_replace('/\033\[[0-9;]*m/', '', $line);
     }
 
-    /** @return array<string, string> */
-    protected function gatherDynamicOptions(): array
+    /**
+     * Preload the Scotty file so its @option declarations can be registered as
+     * real Symfony options before input binding/validation.
+     *
+     * Only the BashParser is preloaded here; Blade-format Scotty files go
+     * through the standard parse path in handle() and don't yet participate
+     * in declaration-based CLI options.
+     */
+    protected function registerDeclaredOptions(InputInterface $input): void
+    {
+        $confOpt = $input->getParameterOption(['--conf'], null, true);
+        $pathOpt = $input->getParameterOption(['--path'], null, true);
+
+        $filePath = null;
+
+        if (is_string($pathOpt) && file_exists($pathOpt)) {
+            $filePath = $pathOpt;
+        } elseif (is_string($confOpt) && file_exists($confOpt)) {
+            $filePath = $confOpt;
+        } else {
+            foreach (self::SCOTTY_FILENAMES as $candidate) {
+                if (file_exists($candidate)) {
+                    $filePath = $candidate;
+                    break;
+                }
+            }
+        }
+
+        if ($filePath === null) {
+            return;
+        }
+
+        $parser = $this->resolveParser($filePath);
+
+        if (! $parser instanceof BashParser) {
+            return;
+        }
+
+        $config = $parser->parse($filePath);
+
+        foreach ($config->options as $option) {
+            if ($option->isBoolean) {
+                $this->addOption($option->name, null, InputOption::VALUE_NONE, '');
+            } else {
+                $this->addOption($option->name, null, InputOption::VALUE_REQUIRED, '', $option->default);
+            }
+        }
+
+        $this->preloadedConfig = $config;
+        $this->preloadedFilePath = $filePath;
+    }
+
+    /**
+     * Resolve values for the options declared in the Scotty file.
+     *
+     * Precedence for string-valued options: CLI flag > environment variable > declared default.
+     * Boolean flags are always sourced from the CLI (true when passed, absent otherwise).
+     * Required options (declared as `# @option name=`) error here if unresolved.
+     *
+     * @param  array<string, OptionDefinition>  $declared
+     * @return array<string, string>|null  null when a required option is missing (error already reported).
+     */
+    protected function resolveDeclaredOptions(array $declared): ?array
     {
         $data = [];
 
-        $argv = $_SERVER['argv'] ?? [];
+        foreach ($declared as $option) {
+            $key = $option->name;
+            $snakeCase = str_replace('-', '_', $key);
+            $envKey = strtoupper($snakeCase);
 
-        foreach ($argv as $argument) {
-            if (! preg_match('/^--([a-zA-Z][\w-]*)=(.+)$/', $argument, $match)) {
-                continue;
+            if ($option->isBoolean) {
+                if (! $this->option($key)) {
+                    continue;
+                }
+
+                $value = '1';
+            } else {
+                $cliPassed = $this->input->hasParameterOption(['--'.$key], true);
+                $envValue = getenv($envKey);
+
+                if ($cliPassed) {
+                    $value = $this->option($key);
+                } elseif ($envValue !== false && $envValue !== '') {
+                    $value = $envValue;
+                } else {
+                    $value = $option->default;
+                }
+
+                if ($option->isRequired && ($value === null || $value === '')) {
+                    error("Missing required option --{$key}. Declare a default with `# @option {$key}=value` or pass `--{$key}=...`.");
+
+                    return null;
+                }
+
+                if ($value === null) {
+                    continue;
+                }
             }
-
-            $key = $match[1];
-
-            if (in_array($key, ['continue', 'pretend', 'path', 'conf', 'summary'])) {
-                continue;
-            }
-
-            $data[$key] = $match[2];
 
             $camelCase = lcfirst(str_replace(' ', '', ucwords(str_replace('-', ' ', $key))));
-            $snakeCase = str_replace('-', '_', $key);
 
-            $data[$camelCase] = $match[2];
-            $data[$snakeCase] = $match[2];
+            $data[$key] = $value;
+            $data[$snakeCase] = $value;
+            $data[$camelCase] = $value;
         }
 
         return $data;

--- a/app/Execution/Executor.php
+++ b/app/Execution/Executor.php
@@ -92,10 +92,17 @@ class Executor
     {
         $preamble = $config->variablePreamble;
 
+        $seen = [];
+
         foreach ($env as $key => $value) {
-            $upperKey = strtoupper($key);
-            $escapedValue = escapeshellarg($value);
-            $preamble .= "\n{$upperKey}={$escapedValue}";
+            $upperKey = strtoupper(str_replace('-', '_', $key));
+
+            if (isset($seen[$upperKey])) {
+                continue;
+            }
+
+            $seen[$upperKey] = true;
+            $preamble .= "\n{$upperKey}=".escapeshellarg($value);
         }
 
         $debugTrap = "trap 'echo \"ENVOY_TRACE:\$BASH_COMMAND\" >&2' DEBUG";

--- a/app/Execution/SshCommandBuilder.php
+++ b/app/Execution/SshCommandBuilder.php
@@ -59,11 +59,21 @@ class SshCommandBuilder
         $delimiter = 'EOF-SCOTTY';
 
         $exports = [];
+        $seen = [];
 
         foreach ($env as $key => $value) {
-            if ($value !== '') {
-                $exports[] = "export {$key}=\"{$value}\"";
+            if ($value === '') {
+                continue;
             }
+
+            $upperKey = strtoupper(str_replace('-', '_', $key));
+
+            if (isset($seen[$upperKey])) {
+                continue;
+            }
+
+            $seen[$upperKey] = true;
+            $exports[] = "export {$upperKey}=\"{$value}\"";
         }
 
         $parts = [

--- a/app/Parsing/BashParser.php
+++ b/app/Parsing/BashParser.php
@@ -13,8 +13,56 @@ class BashParser implements ParserInterface
             tasks: $this->parseTasks($content),
             macros: $this->parseMacros($content),
             hooks: $this->parseHooks($content),
-            variablePreamble: $this->parseVariables($content, $data),
+            variablePreamble: $this->parseVariables($content),
+            options: $this->parseOptions($content),
         );
+    }
+
+    /** @return array<string, OptionDefinition> */
+    protected function parseOptions(string $content): array
+    {
+        $options = [];
+
+        preg_match_all(
+            '/^#\s*@option\s+([a-zA-Z][\w-]*)(=(.*))?\s*$/m',
+            $content,
+            $matches,
+            PREG_SET_ORDER | PREG_UNMATCHED_AS_NULL,
+        );
+
+        foreach ($matches as $match) {
+            $name = $match[1];
+            $hasEquals = $match[2] !== null;
+
+            if (! $hasEquals) {
+                $options[$name] = new OptionDefinition(
+                    name: $name,
+                    isBoolean: true,
+                    isRequired: false,
+                    default: null,
+                );
+
+                continue;
+            }
+
+            $value = trim($match[3] ?? '');
+
+            if (strlen($value) >= 2 && (
+                ($value[0] === '"' && substr($value, -1) === '"') ||
+                ($value[0] === "'" && substr($value, -1) === "'")
+            )) {
+                $value = substr($value, 1, -1);
+            }
+
+            $options[$name] = new OptionDefinition(
+                name: $name,
+                isBoolean: false,
+                isRequired: $value === '',
+                default: $value === '' ? null : $value,
+            );
+        }
+
+        return $options;
     }
 
     /** @return array<string, ServerDefinition> */
@@ -134,7 +182,7 @@ class BashParser implements ParserInterface
         return $hooks;
     }
 
-    protected function parseVariables(string $content, array $cliData): string
+    protected function parseVariables(string $content): string
     {
         $lines = [];
 
@@ -155,12 +203,6 @@ class BashParser implements ParserInterface
         }
 
         $helperFunctions = $this->extractHelperFunctions($content);
-
-        foreach ($cliData as $key => $value) {
-            $escapedValue = escapeshellarg($value);
-            $upperKey = strtoupper($key);
-            $lines[] = "{$upperKey}={$escapedValue}";
-        }
 
         $preamble = implode("\n", $lines);
 

--- a/app/Parsing/OptionDefinition.php
+++ b/app/Parsing/OptionDefinition.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Parsing;
+
+class OptionDefinition
+{
+    public function __construct(
+        public string $name,
+        public bool $isBoolean,
+        public bool $isRequired,
+        public ?string $default,
+    ) {}
+}

--- a/app/Parsing/ParseResult.php
+++ b/app/Parsing/ParseResult.php
@@ -14,6 +14,8 @@ class ParseResult
         /** @var array<HookDefinition> */
         public array $hooks = [],
         public string $variablePreamble = '',
+        /** @var array<string, OptionDefinition> */
+        public array $options = [],
     ) {}
 
     public function getTask(string $name): ?TaskDefinition

--- a/docs/advanced-usage/zero-downtime-deployments.md
+++ b/docs/advanced-usage/zero-downtime-deployments.md
@@ -44,6 +44,8 @@ Create a `Scotty.sh` file in your project root. We'll start with some variables:
 
 # @servers local=127.0.0.1 remote=deployer@your-server.com
 
+# @option branch=main
+
 BASE_DIR="/var/www/my-app"
 RELEASES_DIR="$BASE_DIR/releases"
 PERSISTENT_DIR="$BASE_DIR/persistent"
@@ -51,7 +53,6 @@ CURRENT_DIR="$BASE_DIR/current"
 NEW_RELEASE_NAME=$(date +%Y%m%d-%H%M%S)
 NEW_RELEASE_DIR="$RELEASES_DIR/$NEW_RELEASE_NAME"
 REPOSITORY="your-org/your-repo"
-BRANCH="${BRANCH:-main}"
 ```
 
 Replace `deployer@your-server.com` with your actual server, and `your-org/your-repo` with your GitHub repository. The release name is a timestamp, so every deploy gets its own unique directory. `BRANCH` defaults to `main`, but you can override it later with `scotty run deploy --branch=develop`.
@@ -215,6 +216,8 @@ Here's everything in one file, ready to copy into your project:
 # @servers local=127.0.0.1 remote=deployer@your-server.com
 # @macro deploy startDeployment cloneRepository runComposer buildAssets updateSymlinks migrateDatabase blessNewRelease cleanOldReleases
 
+# @option branch=main
+
 BASE_DIR="/var/www/my-app"
 RELEASES_DIR="$BASE_DIR/releases"
 PERSISTENT_DIR="$BASE_DIR/persistent"
@@ -222,7 +225,6 @@ CURRENT_DIR="$BASE_DIR/current"
 NEW_RELEASE_NAME=$(date +%Y%m%d-%H%M%S)
 NEW_RELEASE_DIR="$RELEASES_DIR/$NEW_RELEASE_NAME"
 REPOSITORY="your-org/your-repo"
-BRANCH="${BRANCH:-main}"
 
 # @task on:local
 startDeployment() {

--- a/docs/basic-usage/bash-format.md
+++ b/docs/basic-usage/bash-format.md
@@ -112,13 +112,19 @@ NEW_RELEASE_NAME=$(date +%Y%m%d-%H%M%S)
 
 These are plain bash variables, so computed values like `$(date)` work naturally. All variables are available in all tasks.
 
-You can also pass variables from the command line:
+You can also accept variables from the command line by declaring them with `# @option`. Three forms are supported:
 
 ```bash
-scotty run deploy --branch=develop
+# @option staging          # boolean flag — $STAGING='1' when --staging is passed
+# @option branch=main      # value with default — $BRANCH='main' unless overridden
+# @option release-name=    # required value — scotty errors if --release-name=... is missing
 ```
 
-The key gets uppercased and dashes become underscores, so `--branch=develop` sets `$BRANCH` to `develop`.
+```bash
+scotty run deploy --branch=develop --release-name=v42 --staging
+```
+
+The key gets uppercased and dashes become underscores, so `--release-name=v42` sets `$RELEASE_NAME`. Value options also fall back to an environment variable of the same (uppercased) name before using the declared default. See [Dynamic options](/docs/scotty/v1/basic-usage/running-tasks#dynamic-options) for the full precedence rules.
 
 ## Helper functions
 

--- a/docs/basic-usage/running-tasks.md
+++ b/docs/basic-usage/running-tasks.md
@@ -48,15 +48,40 @@ This hides task output and only shows results. Failed tasks always show their ou
 
 ## Dynamic options
 
-You can pass custom variables from the command line:
+Declare every option you want to accept at the top of your Scotty.sh file with `# @option`. There are three forms:
 
 ```bash
-scotty run deploy --branch=develop
+# @option staging          # boolean flag: $STAGING='1' when --staging is passed, unset otherwise
+# @option branch=main      # optional value with a default: $BRANCH='main' unless overridden
+# @option tag=             # required value: scotty errors if --tag=... isn't passed
 ```
 
-In the Scotty.sh format, `--branch=develop` becomes `$BRANCH`. The key is uppercased and dashes become underscores.
+```bash
+scotty run deploy --branch=develop --tag=v1.2 --staging
+```
 
-In the Blade format, it becomes available as `$branch`.
+### Naming
+
+An option named `branch` is exposed to your tasks as `$BRANCH`. The same rule applies to the CLI flag, the environment variable Scotty looks up, and the assignment written into the script preamble: each option has exactly **one** canonical bash name.
+
+The transformation is:
+
+- Dashes become underscores (`release-name` → `release_name`)
+- The result is uppercased (`release_name` → `RELEASE_NAME`)
+
+So `# @option release-name=latest` declares a CLI flag `--release-name=...`, an env var `$RELEASE_NAME`, and a script variable `$RELEASE_NAME` — all one and the same. Flags that aren't declared are rejected with `The "--foo" option does not exist.`
+
+### Precedence
+
+For value options, Scotty resolves each variable in this order:
+
+1. CLI flag (`--branch=develop` or `--release-name=v42`)
+2. Environment variable of the canonical bash name (`BRANCH=develop scotty run deploy`, `RELEASE_NAME=v42 scotty run deploy`)
+3. Declared default (`# @option branch=main`)
+
+Boolean flags only read from the CLI — `$STAGING` is unset unless `--staging` was passed on this invocation.
+
+> Note: `@option` declarations are currently supported in the Scotty.sh (bash) format. Blade-format files ignore `@option` and continue to forward any passed CLI flag as a Blade variable.
 
 ## Pause and resume
 

--- a/docs/basic-usage/your-first-deploy-script.md
+++ b/docs/basic-usage/your-first-deploy-script.md
@@ -116,10 +116,10 @@ Sometimes you want to deploy a different branch. Instead of editing the file eac
 scotty run deploy --branch=develop
 ```
 
-Command line options are available as uppercased variables. Use a default so it works without the flag too:
+Declare the option with `# @option` so Scotty knows to accept it. The value after `=` is the default used when the flag is omitted:
 
 ```bash
-BRANCH="${BRANCH:-main}"
+# @option branch=main
 
 # @task on:remote
 pullCode() {
@@ -152,8 +152,9 @@ Here's everything together:
 # @servers remote=deployer@your-server.com
 # @macro deploy pullCode runComposer runMigrations clearCaches restartWorkers
 
+# @option branch=main
+
 APP_DIR="/var/www/my-app"
-BRANCH="${BRANCH:-main}"
 
 # @task on:remote confirm="Deploy to production?"
 pullCode() {

--- a/tests/Feature/RunCommandTest.php
+++ b/tests/Feature/RunCommandTest.php
@@ -61,6 +61,428 @@ it('runs local tasks without formatting errors', function () {
         ->and($output)->not->toContain('Invalid option specified');
 });
 
+it('writes each option assignment into the preamble exactly once', function () {
+    $fixture = $this->fixturePath.'/dedupe-preamble.sh';
+    file_put_contents($fixture, <<<'BASH'
+# @servers local=127.0.0.1
+
+# @option branch=main
+# @option release-name=latest
+
+# @task on:local
+deploy() {
+    echo "b=$BRANCH r=$RELEASE_NAME"
+}
+BASH);
+
+    try {
+        Artisan::call('run', [
+            'task' => 'deploy',
+            '--pretend' => true,
+            '--conf' => $fixture,
+            '--branch' => 'develop',
+            '--release-name' => 'v42',
+        ]);
+
+        $output = Artisan::output();
+
+        expect(substr_count($output, "BRANCH='develop'"))->toBe(1)
+            ->and(substr_count($output, "RELEASE_NAME='v42'"))->toBe(1);
+    } finally {
+        @unlink($fixture);
+    }
+});
+
+it('forwards declared options as uppercase env vars', function () {
+    $fixture = $this->fixturePath.'/declared-options.sh';
+    file_put_contents($fixture, <<<'BASH'
+# @servers local=127.0.0.1
+
+# @option branch=main
+
+# @task on:local
+deploy() {
+    echo "branch=$BRANCH"
+}
+BASH);
+
+    try {
+        $exitCode = Artisan::call('run', [
+            'task' => 'deploy',
+            '--pretend' => true,
+            '--conf' => $fixture,
+            '--branch' => 'develop',
+        ]);
+
+        $output = Artisan::output();
+
+        expect($exitCode)->toBe(0)
+            ->and($output)->toContain("BRANCH='develop'");
+    } finally {
+        @unlink($fixture);
+    }
+});
+
+it('falls back to declared default when option flag is omitted', function () {
+    $fixture = $this->fixturePath.'/declared-options-default.sh';
+    file_put_contents($fixture, <<<'BASH'
+# @servers local=127.0.0.1
+
+# @option branch=main
+
+# @task on:local
+deploy() {
+    echo "branch=$BRANCH"
+}
+BASH);
+
+    try {
+        $exitCode = Artisan::call('run', [
+            'task' => 'deploy',
+            '--pretend' => true,
+            '--conf' => $fixture,
+        ]);
+
+        $output = Artisan::output();
+
+        expect($exitCode)->toBe(0)
+            ->and($output)->toContain("BRANCH='main'");
+    } finally {
+        @unlink($fixture);
+    }
+});
+
+it('rejects undeclared flags', function () {
+    $fixture = $this->fixturePath.'/no-options.sh';
+    file_put_contents($fixture, <<<'BASH'
+# @servers local=127.0.0.1
+
+# @task on:local
+deploy() {
+    echo "hi"
+}
+BASH);
+
+    try {
+        Artisan::call('run', [
+            'task' => 'deploy',
+            '--pretend' => true,
+            '--conf' => $fixture,
+            '--branch' => 'develop',
+        ]);
+
+        test()->fail('Expected an exception for undeclared --branch flag.');
+    } catch (\Symfony\Component\Console\Exception\ExceptionInterface $e) {
+        expect($e->getMessage())->toContain('--branch');
+    } finally {
+        @unlink($fixture);
+    }
+});
+
+it('exposes dashed option names as snake_case uppercase env vars', function () {
+    $fixture = $this->fixturePath.'/dashed-options.sh';
+    file_put_contents($fixture, <<<'BASH'
+# @servers local=127.0.0.1
+
+# @option release-name=latest
+
+# @task on:local
+deploy() {
+    echo "release=$RELEASE_NAME"
+}
+BASH);
+
+    try {
+        $exitCode = Artisan::call('run', [
+            'task' => 'deploy',
+            '--pretend' => true,
+            '--conf' => $fixture,
+            '--release-name' => 'v42',
+        ]);
+
+        $output = Artisan::output();
+
+        expect($exitCode)->toBe(0)
+            ->and($output)->toContain("RELEASE_NAME='v42'");
+    } finally {
+        @unlink($fixture);
+    }
+});
+
+it('omits preamble assignment when option has no default and flag is not passed', function () {
+    $fixture = $this->fixturePath.'/optional-no-default.sh';
+    file_put_contents($fixture, <<<'BASH'
+# @servers local=127.0.0.1
+
+# @option tag
+
+# @task on:local
+deploy() {
+    echo "tag=${TAG:-none}"
+}
+BASH);
+
+    try {
+        $exitCode = Artisan::call('run', [
+            'task' => 'deploy',
+            '--pretend' => true,
+            '--conf' => $fixture,
+        ]);
+
+        $output = Artisan::output();
+
+        expect($exitCode)->toBe(0)
+            ->and($output)->not->toContain('TAG=');
+    } finally {
+        @unlink($fixture);
+    }
+});
+
+it('exposes boolean @option flags as 1 when passed', function () {
+    $fixture = $this->fixturePath.'/bool-flag.sh';
+    file_put_contents($fixture, <<<'BASH'
+# @servers local=127.0.0.1
+
+# @option staging
+
+# @task on:local
+deploy() {
+    echo "staging=$STAGING"
+}
+BASH);
+
+    try {
+        Artisan::call('run', [
+            'task' => 'deploy',
+            '--pretend' => true,
+            '--conf' => $fixture,
+            '--staging' => true,
+        ]);
+
+        $output = Artisan::output();
+
+        expect($output)->toContain("STAGING='1'");
+    } finally {
+        @unlink($fixture);
+    }
+});
+
+it('omits boolean @option flag when not passed', function () {
+    $fixture = $this->fixturePath.'/bool-flag-omitted.sh';
+    file_put_contents($fixture, <<<'BASH'
+# @servers local=127.0.0.1
+
+# @option staging
+
+# @task on:local
+deploy() {
+    echo "hi"
+}
+BASH);
+
+    try {
+        Artisan::call('run', [
+            'task' => 'deploy',
+            '--pretend' => true,
+            '--conf' => $fixture,
+        ]);
+
+        $output = Artisan::output();
+
+        expect($output)->not->toContain('STAGING=');
+    } finally {
+        @unlink($fixture);
+    }
+});
+
+it('errors when a required @option is not provided', function () {
+    $fixture = $this->fixturePath.'/required-option.sh';
+    file_put_contents($fixture, <<<'BASH'
+# @servers local=127.0.0.1
+
+# @option branch=
+
+# @task on:local
+deploy() {
+    echo "branch=$BRANCH"
+}
+BASH);
+
+    try {
+        $exitCode = Artisan::call('run', [
+            'task' => 'deploy',
+            '--pretend' => true,
+            '--conf' => $fixture,
+        ]);
+
+        $output = Artisan::output();
+
+        expect($exitCode)->toBe(1)
+            ->and($output)->toContain('--branch');
+    } finally {
+        @unlink($fixture);
+    }
+});
+
+it('accepts a required @option when provided via CLI', function () {
+    $fixture = $this->fixturePath.'/required-provided.sh';
+    file_put_contents($fixture, <<<'BASH'
+# @servers local=127.0.0.1
+
+# @option branch=
+
+# @task on:local
+deploy() {
+    echo "branch=$BRANCH"
+}
+BASH);
+
+    try {
+        $exitCode = Artisan::call('run', [
+            'task' => 'deploy',
+            '--pretend' => true,
+            '--conf' => $fixture,
+            '--branch' => 'release/1.0',
+        ]);
+
+        $output = Artisan::output();
+
+        expect($exitCode)->toBe(0)
+            ->and($output)->toContain("BRANCH='release/1.0'");
+    } finally {
+        @unlink($fixture);
+    }
+});
+
+it('reads string @option from env var when no CLI flag passed', function () {
+    $fixture = $this->fixturePath.'/env-fallback.sh';
+    file_put_contents($fixture, <<<'BASH'
+# @servers local=127.0.0.1
+
+# @option branch=main
+
+# @task on:local
+deploy() {
+    echo "branch=$BRANCH"
+}
+BASH);
+
+    putenv('BRANCH=fromenv');
+
+    try {
+        Artisan::call('run', [
+            'task' => 'deploy',
+            '--pretend' => true,
+            '--conf' => $fixture,
+        ]);
+
+        $output = Artisan::output();
+
+        expect($output)->toContain("BRANCH='fromenv'");
+    } finally {
+        putenv('BRANCH');
+        @unlink($fixture);
+    }
+});
+
+it('prefers CLI flag over env var even when the CLI value equals the declared default', function () {
+    $fixture = $this->fixturePath.'/cli-equals-default.sh';
+    file_put_contents($fixture, <<<'BASH'
+# @servers local=127.0.0.1
+
+# @option branch=main
+
+# @task on:local
+deploy() {
+    echo "branch=$BRANCH"
+}
+BASH);
+
+    putenv('BRANCH=fromenv');
+
+    try {
+        Artisan::call('run', [
+            'task' => 'deploy',
+            '--pretend' => true,
+            '--conf' => $fixture,
+            '--branch' => 'main',
+        ]);
+
+        $output = Artisan::output();
+
+        expect($output)->toContain("BRANCH='main'")
+            ->and($output)->not->toContain("BRANCH='fromenv'");
+    } finally {
+        putenv('BRANCH');
+        @unlink($fixture);
+    }
+});
+
+it('prefers CLI flag over env var for string @option', function () {
+    $fixture = $this->fixturePath.'/env-cli-precedence.sh';
+    file_put_contents($fixture, <<<'BASH'
+# @servers local=127.0.0.1
+
+# @option branch=main
+
+# @task on:local
+deploy() {
+    echo "branch=$BRANCH"
+}
+BASH);
+
+    putenv('BRANCH=fromenv');
+
+    try {
+        Artisan::call('run', [
+            'task' => 'deploy',
+            '--pretend' => true,
+            '--conf' => $fixture,
+            '--branch' => 'fromcli',
+        ]);
+
+        $output = Artisan::output();
+
+        expect($output)->toContain("BRANCH='fromcli'");
+    } finally {
+        putenv('BRANCH');
+        @unlink($fixture);
+    }
+});
+
+it('accepts declared flags via ArgvInput regardless of position', function () {
+    $fixture = $this->fixturePath.'/argv-order.sh';
+    file_put_contents($fixture, <<<'BASH'
+# @servers local=127.0.0.1
+
+# @option branch=main
+
+# @task on:local
+deploy() {
+    echo "branch=$BRANCH"
+}
+BASH);
+
+    $binary = base_path('scotty');
+
+    try {
+        $process = new \Symfony\Component\Process\Process([
+            PHP_BINARY,
+            $binary,
+            'run',
+            'deploy',
+            '--branch=develop',
+            '--conf='.$fixture,
+            '--pretend',
+        ]);
+        $process->run();
+
+        expect($process->getOutput())->toContain("BRANCH='develop'");
+    } finally {
+        @unlink($fixture);
+    }
+});
+
 it('shows error when no file found', function () {
     $tempDir = sys_get_temp_dir().'/scotty-run-test-'.uniqid();
     mkdir($tempDir);

--- a/tests/Unit/BashParserTest.php
+++ b/tests/Unit/BashParserTest.php
@@ -281,25 +281,6 @@ BASH);
     @unlink($fixture);
 });
 
-it('adds cli data to variable preamble', function () {
-    $fixture = $this->fixturePath.'/simple.sh';
-    file_put_contents($fixture, <<<'BASH'
-# @servers local=127.0.0.1
-
-# @task on:local
-deploy() {
-    echo "deploying $BRANCH"
-}
-BASH);
-
-    $result = $this->parser->parse($fixture, ['branch' => 'main', 'env' => 'production']);
-
-    expect($result->variablePreamble)->toContain("BRANCH='main'")
-        ->and($result->variablePreamble)->toContain("ENV='production'");
-
-    @unlink($fixture);
-});
-
 it('parses emoji from task annotation', function () {
     $fixture = $this->fixturePath.'/emoji.sh';
     file_put_contents($fixture, <<<'BASH'
@@ -320,6 +301,39 @@ BASH);
 
     expect($result->getTask('deploy')->emoji)->toBe('🚀')
         ->and($result->getTask('noEmoji')->emoji)->toBeNull();
+
+    @unlink($fixture);
+});
+
+it('parses @option declarations in all three forms', function () {
+    $fixture = $this->fixturePath.'/options.sh';
+    file_put_contents($fixture, <<<'BASH'
+# @servers local=127.0.0.1
+
+# @option staging
+# @option branch=main
+# @option env="production"
+# @option tag=
+
+# @task on:local
+deploy() {
+    echo "deploying"
+}
+BASH);
+
+    $result = $this->parser->parse($fixture);
+
+    expect($result->options)->toHaveCount(4)
+        ->and($result->options['staging']->isBoolean)->toBeTrue()
+        ->and($result->options['staging']->isRequired)->toBeFalse()
+        ->and($result->options['staging']->default)->toBeNull()
+        ->and($result->options['branch']->isBoolean)->toBeFalse()
+        ->and($result->options['branch']->isRequired)->toBeFalse()
+        ->and($result->options['branch']->default)->toBe('main')
+        ->and($result->options['env']->default)->toBe('production')
+        ->and($result->options['tag']->isBoolean)->toBeFalse()
+        ->and($result->options['tag']->isRequired)->toBeTrue()
+        ->and($result->options['tag']->default)->toBeNull();
 
     @unlink($fixture);
 });

--- a/tests/Unit/SshCommandBuilderTest.php
+++ b/tests/Unit/SshCommandBuilderTest.php
@@ -75,6 +75,21 @@ it('includes environment variable exports in remote command', function () {
         ->and($command)->toContain('export BRANCH="main"');
 });
 
+it('normalises lowercase and dashed env keys to uppercase snake_case, deduping variants', function () {
+    $command = $this->builder->buildCommand('forge@1.1.1.1', 'echo "hello"', [
+        'branch' => 'develop',
+        'Branch' => 'develop',
+        'release-name' => 'v42',
+        'release_name' => 'v42',
+        'releaseName' => 'v42',
+    ]);
+
+    expect(substr_count($command, 'export BRANCH="develop"'))->toBe(1)
+        ->and(substr_count($command, 'export RELEASE_NAME="v42"'))->toBe(1)
+        ->and($command)->not->toContain('export branch=')
+        ->and($command)->not->toContain('export release-name=');
+});
+
 it('includes set -e in remote command', function () {
     $command = $this->builder->buildCommand('forge@1.1.1.1', 'echo "hello"');
 


### PR DESCRIPTION
## Summary

The docs advertise that you can pass custom variables from the command line (e.g. `scotty run deploy --branch=develop` → `$BRANCH`), but in practice any undeclared flag is rejected by Symfony Console before `RunCommand::handle()` runs — the existing `gatherDynamicOptions()` method is unreachable from a real CLI invocation. Repro on current `main`:

```
$ scotty run deploy --branch=develop
  The "--branch" option does not exist.
```

This PR makes that feature actually work by introducing a **declarative `@option`** annotation.

## Design

The Envoy-style approach would be to accept arbitrary `--vars` at the CLI and forward them. That's what the current code *tries* to do, and it'd be the most familiar option for Laravel devs coming from Envoy.

But it felt off for Scotty: every other piece of metadata in a `Scotty.sh` is declarative (`# @servers`, `# @task`, `# @macro`, `# @before`, etc.). Arbitrary-flag forwarding is the odd one out — the script silently accepts whatever you throw at it, with no contract about what it expects. A declared option matches the rest of the annotation-driven surface.

The first cut only had one form: `# @option branch=main`. It worked, but as Laravel developers we kept reaching for the full signature-string taxonomy that Artisan commands use — boolean flags, required values, and values with defaults — because deploy scripts genuinely need all three. So the final design mirrors Laravel's own signature syntax.

## The three forms

```bash
# @option staging          # boolean flag: $STAGING='1' when --staging is passed, unset otherwise
# @option branch=main      # optional value with a default
# @option tag=             # required value: errors if --tag=... is not passed
```

All three are distinguished by the `=` sign alone — no explicit type annotation needed.

## Precedence (value options)

1. CLI flag (`--branch=develop`)
2. Environment variable (`BRANCH=develop scotty run deploy`)
3. Declared default

Env-var support was previously partial on `main`: `BRANCH="${BRANCH:-main}"` at the top of a `Scotty.sh` worked for local tasks (Symfony Process inherits parent env) but silently did nothing on remote tasks (SSH doesn't forward env, and the broken `gatherDynamicOptions()` couldn't inject it into the heredoc). With this change, env-var fallback is resolved in PHP before the script is built, so it works the same whether the task runs locally or over SSH.

### Trade-off worth flagging

The env var name is unprefixed (`$BRANCH`, not `$SCOTTY_BRANCH`). This matches the existing `${BRANCH:-main}` idiom the docs teach. Trade-off: an ambient `$BRANCH` exported by another tool (direnv, CI, git helper) will be picked up. Happy to switch to a `SCOTTY_*` prefix if you'd prefer stricter isolation.

## How it works

- `BashParser::parseOptions()` extracts `@option` declarations into `OptionDefinition` instances (name, isBoolean, isRequired, default).
- `RunCommand::run()` is overridden to preload the Scotty file early and call `\$this->addOption()` for each declaration — before Symfony's input binding — so undeclared flags get rejected by the normal `The \"--foo\" option does not exist.` validation, and declared ones type-check naturally.
- `RunCommand::resolveDeclaredOptions()` reads each option via `\$this->input->hasParameterOption()` (to distinguish "flag passed" from "flag happens to match default"), falls back to env, then default.
- Blade-format Scotty files are untouched by this change — they go through the existing parse path.

## Docs updated

- `docs/basic-usage/running-tasks.md` — new "Dynamic options" section with all three forms and precedence rules
- `docs/basic-usage/bash-format.md` — shorter reference pointing at running-tasks
- `docs/basic-usage/your-first-deploy-script.md` — example now uses `# @option branch=main` instead of `BRANCH=\"\${BRANCH:-main}\"`
- `docs/advanced-usage/zero-downtime-deployments.md` — same substitution in both code samples

## Test plan

- [x] `./vendor/bin/pest` — 95 tests passing (7 new feature tests, 1 new unit test, 1 existing unit test updated for the new `OptionDefinition` shape)
- [x] Manual CLI repros for each form (boolean, optional-with-default, required) and for env-var fallback
- [x] Regression test: CLI value that equals the declared default still wins over env var (caught a latent bug during review)
- [x] ArgvInput regression test via `Symfony\Process` subprocess guards against the order-sensitive binding bug