### PR TITLE
Build and attach a phar to each release

### DIFF
--- a/.github/workflows/build-phar.yml
+++ b/.github/workflows/build-phar.yml
@@ -1,0 +1,32 @@
+name: Build phar
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          extensions: mbstring, zip
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Build phar
+        run: php scotty app:build --build-version=${{ github.event.release.tag_name }} --no-interaction
+
+      - name: Attach phar to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: builds/scotty

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor
+/builds
 /.idea
 /.vscode
 /.vagrant

--- a/README.md
+++ b/README.md
@@ -41,6 +41,24 @@ clearCache() {
 
 Run it with `scotty run deploy`.
 
+## Installation
+
+Scotty ships as a single-file phar. The recommended way to install it per project is:
+
+```bash
+curl -L https://github.com/spatie/scotty/releases/latest/download/scotty -o scotty
+chmod +x scotty
+./scotty list
+```
+
+You can also install it globally with Composer:
+
+```bash
+composer global require spatie/scotty
+```
+
+See the [installation docs](https://spatie.be/docs/scotty/v1/installation-setup) for details and other options.
+
 ## Support us
 
 [<img src="https://github-ads.s3.eu-central-1.amazonaws.com/scotty.jpg?t=1" width="419px" />](https://spatie.be/github-ad-click/scotty)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,6 +3,22 @@ title: Installation & setup
 weight: 4
 ---
 
+Scotty ships as a single-file phar executable. There are two ways to install it.
+
+## Per project (recommended)
+
+Download the phar from the latest GitHub release and drop it into your project:
+
+```bash
+curl -L https://github.com/spatie/scotty/releases/latest/download/scotty -o scotty
+chmod +x scotty
+./scotty list
+```
+
+Commit the phar to your repository so everyone on the team uses the same version, or fetch it during your build step.
+
+## Globally
+
 You can install Scotty as a global Composer package:
 
 ```bash
@@ -20,6 +36,8 @@ Once installed, you should be able to run:
 ```bash
 scotty list
 ```
+
+> Installing Scotty as a per-project Composer dev dependency (`composer require --dev spatie/scotty`) is not supported. Scotty is a Laravel Zero application and its `illuminate/*` requirements will conflict with the host application's. Use the phar download or the global install instead.
 
 ## Creating your first Scotty file
 


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that builds Scotty's phar on release publication and attaches it as a release asset.
- Updates the README and installation docs with a `curl`-based per-project install path.
- Stops tracking the stale `builds/scotty` binary in git.

## Why

Scotty is a Laravel Zero application, so `composer require --dev spatie/scotty` fails or breaks at runtime in any non-trivial host app. That's the root cause of issues #2 and #3. Releasing a phar is the canonical way Laravel Zero apps support per-project usage; the tooling (`php scotty app:build` + the bundled Box phar) is already in the repo, it just wasn't wired up to releases.

## Notes

- The workflow stamps the release tag into the phar via `--build-version`, so `scotty --version` reports the correct version.
- I removed `builds/scotty` from the repo because the workflow now produces it on each release. Keeping a stale, hand-built copy in git would just mislead readers.
- After this lands and the next release runs the workflow, we can close issues #2 and #3 by pointing at the phar install instructions.