### PR TITLE
Support custom SSH port via host:port syntax

### DIFF
--- a/app/Execution/SshCommandBuilder.php
+++ b/app/Execution/SshCommandBuilder.php
@@ -16,14 +16,15 @@ class SshCommandBuilder
     public function buildProcess(string $host, string $script, array $env = []): Process
     {
         $env['ENVOY_HOST'] = $host;
-        $target = $this->resolveHost($host);
+        [$bareHost, $port] = $this->extractPort($host);
+        $target = $this->resolveHost($bareHost);
 
         if (ServerDefinition::isLocalHost($target)) {
             return Process::fromShellCommandline($script, null, $env)
                 ->setTimeout(null);
         }
 
-        $command = $this->buildSshCommand($target, $script, $env);
+        $command = $this->buildSshCommand($target, $port, $script, $env);
 
         return Process::fromShellCommandline($command)
             ->setTimeout(null);
@@ -33,13 +34,24 @@ class SshCommandBuilder
     public function buildCommand(string $host, string $script, array $env = []): string
     {
         $env['ENVOY_HOST'] = $host;
-        $target = $this->resolveHost($host);
+        [$bareHost, $port] = $this->extractPort($host);
+        $target = $this->resolveHost($bareHost);
 
         if (ServerDefinition::isLocalHost($target)) {
             return $script;
         }
 
-        return $this->buildSshCommand($target, $script, $env);
+        return $this->buildSshCommand($target, $port, $script, $env);
+    }
+
+    /** @return array{string, ?int} */
+    protected function extractPort(string $host): array
+    {
+        if (preg_match('/^(.+):(\d+)$/', $host, $match)) {
+            return [$match[1], (int) $match[2]];
+        }
+
+        return [$host, null];
     }
 
     protected function resolveHost(string $host): string
@@ -54,9 +66,10 @@ class SshCommandBuilder
     }
 
     /** @param array<string, string> $env */
-    protected function buildSshCommand(string $target, string $script, array $env): string
+    protected function buildSshCommand(string $target, ?int $port, string $script, array $env): string
     {
         $delimiter = 'EOF-SCOTTY';
+        $portFlag = $port !== null ? "-p {$port} " : '';
 
         $exports = [];
 
@@ -67,7 +80,7 @@ class SshCommandBuilder
         }
 
         $parts = [
-            "ssh {$target} 'bash -se' << \\{$delimiter}",
+            "ssh {$portFlag}{$target} 'bash -se' << \\{$delimiter}",
             ...$exports,
             'set -e',
             $script,

--- a/docs/basic-usage/bash-format.md
+++ b/docs/basic-usage/bash-format.md
@@ -19,6 +19,14 @@ You can define as many as you need:
 # @servers local=127.0.0.1 web-1=deployer@1.1.1.1 web-2=deployer@2.2.2.2
 ```
 
+If your server listens on a non-default SSH port, append it to the host with a colon:
+
+```bash
+# @servers remote=deployer@your-server.com:2222
+```
+
+For more complex SSH options (identity files, jump hosts, ProxyCommand, etc.), put them in `~/.ssh/config` under a `Host` block and reference that host name from `@servers`.
+
 ## Tasks
 
 A task is just a bash function with a `# @task` annotation above it. The `on:` parameter tells Scotty which server to run it on:

--- a/tests/Unit/SshCommandBuilderTest.php
+++ b/tests/Unit/SshCommandBuilderTest.php
@@ -80,3 +80,28 @@ it('includes set -e in remote command', function () {
 
     expect($command)->toContain('set -e');
 });
+
+it('passes a custom port to ssh when host uses host:port syntax', function () {
+    $command = $this->builder->buildCommand('forge@1.1.1.1:2222', 'echo "hello"');
+
+    expect($command)->toContain('ssh -p 2222 forge@1.1.1.1');
+});
+
+it('passes a custom port for hostnames without a user', function () {
+    $command = $this->builder->buildCommand('example.com:2222', 'echo "hello"');
+
+    expect($command)->toContain('ssh -p 2222 example.com');
+});
+
+it('does not add a port flag when none is specified', function () {
+    $command = $this->builder->buildCommand('forge@1.1.1.1', 'echo "hello"');
+
+    expect($command)->toContain('ssh forge@1.1.1.1')
+        ->and($command)->not->toContain('-p ');
+});
+
+it('does not treat port-like syntax on a local host as a port', function () {
+    $command = $this->builder->buildCommand('127.0.0.1', 'echo "hello"');
+
+    expect($command)->toBe('echo "hello"');
+});


### PR DESCRIPTION
## Summary

- Adds support for `# @servers remote=user@host:2222` to connect on a non-default SSH port.
- Port is extracted at the SSH command boundary and passed via `-p`.
- SSH config lookups still apply to the bare host (port extraction happens before `resolveHost`).
- Plain hosts without a port behave exactly as before; existing tests still pass.
- Doc update in `bash-format.md` covering the new syntax and pointing to `~/.ssh/config` for richer setups.

Closes #1.