### PR TITLE
Document global phar installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ chmod +x scotty
 ./scotty list
 ```
 
+To install it globally, drop the phar somewhere on your `$PATH`:
+
+```bash
+curl -L https://github.com/spatie/scotty/releases/latest/download/scotty -o /usr/local/bin/scotty
+chmod +x /usr/local/bin/scotty
+```
+
 You can also install it globally with Composer:
 
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,21 @@ Commit the phar to your repository so everyone on the team uses the same version
 
 ## Globally
 
-You can install Scotty as a global Composer package:
+The simplest way to install Scotty globally is to drop the phar somewhere on your `$PATH`:
+
+```bash
+curl -L https://github.com/spatie/scotty/releases/latest/download/scotty -o /usr/local/bin/scotty
+chmod +x /usr/local/bin/scotty
+scotty list
+```
+
+Any directory on your `$PATH` works. Common alternatives are `~/.local/bin` (no `sudo` needed) or `~/bin`.
+
+To upgrade later, re-run the same `curl` command.
+
+### Via Composer
+
+You can also install Scotty as a global Composer package:
 
 ```bash
 composer global require spatie/scotty


### PR DESCRIPTION
## Summary

The "Globally" section of the install docs only mentioned the Composer install path. Adding a phar-based global install option, since that's now the recommended path after the build-phar workflow shipped in 1.3.0.

- Adds a phar curl + `/usr/local/bin/scotty` snippet to the README and the installation docs.
- Keeps the Composer global install as a secondary option (now under a "Via Composer" subhead).
- Mentions `~/.local/bin` and `~/bin` as no-sudo alternatives.