### PR TITLE
Add self-update support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,19 @@ Run it with `scotty run deploy`.
 
 ## Installation
 
-Scotty ships as a single-file phar. The recommended way to install it per project is:
+Scotty ships as a single-file phar. Downloading the phar is the preferred install. Drop it in your project:
 
 ```bash
 curl -L https://github.com/spatie/scotty/releases/latest/download/scotty -o scotty
 chmod +x scotty
 ./scotty list
+```
+
+Or install it globally on your `$PATH`:
+
+```bash
+curl -L https://github.com/spatie/scotty/releases/latest/download/scotty -o /usr/local/bin/scotty
+chmod +x /usr/local/bin/scotty
 ```
 
 You can also install it globally with Composer:

--- a/app/Commands/RunCommand.php
+++ b/app/Commands/RunCommand.php
@@ -8,7 +8,11 @@ use App\Execution\TaskResult;
 use App\Parsing\OptionDefinition;
 use App\Parsing\ParseResult;
 use App\Parsing\TaskDefinition;
+use App\Updater\SelfUpdater;
+use App\Updater\UpdateCachePath;
+use App\Updater\UpdateChecker;
 use LaravelZero\Framework\Commands\Command;
+use Phar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -30,7 +34,8 @@ class RunCommand extends Command
         {--pretend : Dump the script instead of running it}
         {--path= : Path to the Scotty file}
         {--conf= : Scotty filename}
-        {--summary : Only show task results, hide output}';
+        {--summary : Only show task results, hide output}
+        {--no-update-check : Skip the post-run check for a newer Scotty release}';
 
     protected $description = 'Run a task or macro';
 
@@ -184,7 +189,78 @@ class RunCommand extends Command
         $this->disablePauseDetection();
         $this->writeResultSummary($results);
 
+        $this->offerSelfUpdate();
+
         return $this->failed ? 1 : 0;
+    }
+
+    protected function offerSelfUpdate(): void
+    {
+        if (! $this->shouldOfferUpdate()) {
+            return;
+        }
+
+        $pharPath = Phar::running(false);
+        $currentVersion = $this->getApplication()->getVersion();
+
+        $checker = new UpdateChecker(
+            currentVersion: $currentVersion,
+            cacheDirectory: UpdateCachePath::default(),
+        );
+
+        $newerVersion = $checker->findNewerVersion();
+
+        if ($newerVersion === null) {
+            return;
+        }
+
+        info("A new version of Scotty is available: {$newerVersion} (you're on {$currentVersion}).");
+
+        if (! confirm('Update now?', default: false)) {
+            return;
+        }
+
+        $result = (new SelfUpdater)->update($newerVersion, $pharPath);
+
+        if ($result->succeeded) {
+            info("Updated to {$newerVersion}.");
+
+            return;
+        }
+
+        warning("Update failed: {$result->error}");
+    }
+
+    protected function shouldOfferUpdate(): bool
+    {
+        if ($this->failed) {
+            return false;
+        }
+
+        if ($this->option('no-update-check')) {
+            return false;
+        }
+
+        if ($this->isUpdateCheckDisabledByEnv()) {
+            return false;
+        }
+
+        if (! stream_isatty(STDIN) || ! stream_isatty(STDOUT)) {
+            return false;
+        }
+
+        return Phar::running(false) !== '';
+    }
+
+    protected function isUpdateCheckDisabledByEnv(): bool
+    {
+        $flag = getenv('SCOTTY_NO_UPDATE_CHECK');
+
+        if ($flag === false) {
+            return false;
+        }
+
+        return in_array(strtolower($flag), ['1', 'true', 'yes', 'on'], true);
     }
 
     protected function buildSpinnerContent(): string

--- a/app/Commands/SelfUpdateCommand.php
+++ b/app/Commands/SelfUpdateCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Commands;
+
+use App\Updater\SelfUpdater;
+use App\Updater\UpdateCachePath;
+use App\Updater\UpdateChecker;
+use LaravelZero\Framework\Commands\Command;
+use Phar;
+
+use function Laravel\Prompts\error;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\warning;
+
+class SelfUpdateCommand extends Command
+{
+    protected $signature = 'self-update
+        {--force : Re-download the latest release even if it matches the current version}';
+
+    protected $description = 'Update Scotty to the latest GitHub release';
+
+    public function handle(): int
+    {
+        $pharPath = Phar::running(false);
+
+        if ($pharPath === '') {
+            error('Self-update only works for the phar install. Use `composer global update spatie/scotty` instead.');
+
+            return 1;
+        }
+
+        $currentVersion = $this->getApplication()->getVersion();
+
+        $checker = new UpdateChecker(
+            currentVersion: $currentVersion,
+            cacheDirectory: UpdateCachePath::default(),
+        );
+
+        $newerVersion = $checker->findNewerVersion();
+
+        if ($newerVersion === null && ! $this->option('force')) {
+            info("You're already on the latest version ({$currentVersion}).");
+
+            return 0;
+        }
+
+        $targetVersion = $newerVersion ?? $currentVersion;
+
+        info("Updating Scotty from {$currentVersion} to {$targetVersion}...");
+
+        $result = (new SelfUpdater)->update($targetVersion, $pharPath);
+
+        if ($result->succeeded) {
+            info("Updated to {$targetVersion}.");
+
+            return 0;
+        }
+
+        warning("Update failed: {$result->error}");
+
+        return 1;
+    }
+}

--- a/app/Updater/SelfUpdater.php
+++ b/app/Updater/SelfUpdater.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Updater;
+
+use Throwable;
+
+class SelfUpdater
+{
+    public const MIN_PHAR_SIZE_BYTES = 100_000;
+
+    /** @var callable(string): ?string */
+    protected $downloader;
+
+    public function __construct(
+        protected string $downloadUrlTemplate = 'https://github.com/spatie/scotty/releases/download/{version}/scotty',
+        ?callable $downloader = null,
+    ) {
+        $this->downloader = $downloader ?? fn (string $url): ?string => $this->defaultDownloader($url);
+    }
+
+    public function update(string $version, string $pharPath): UpdateResult
+    {
+        if (! is_writable(dirname($pharPath))) {
+            return UpdateResult::failed("Cannot write to {$pharPath}. Re-run with sudo.");
+        }
+
+        $downloadUrl = str_replace('{version}', $version, $this->downloadUrlTemplate);
+
+        try {
+            $contents = ($this->downloader)($downloadUrl);
+        } catch (Throwable $exception) {
+            return UpdateResult::failed("Download failed: {$exception->getMessage()}");
+        }
+
+        if (! is_string($contents) || $contents === '') {
+            return UpdateResult::failed('Download failed.');
+        }
+
+        if (strlen($contents) < self::MIN_PHAR_SIZE_BYTES) {
+            return UpdateResult::failed('Downloaded phar is suspiciously small, refusing to replace.');
+        }
+
+        $tempPath = $pharPath.'.new';
+
+        if (@file_put_contents($tempPath, $contents) === false) {
+            return UpdateResult::failed("Failed to write temporary file at {$tempPath}.");
+        }
+
+        @chmod($tempPath, 0755);
+
+        if (! @rename($tempPath, $pharPath)) {
+            @unlink($tempPath);
+
+            return UpdateResult::failed("Failed to replace {$pharPath}.");
+        }
+
+        return UpdateResult::success();
+    }
+
+    protected function defaultDownloader(string $url): ?string
+    {
+        $context = stream_context_create([
+            'http' => [
+                'timeout' => 60,
+                'header' => "User-Agent: scotty-self-update\r\n",
+                'follow_location' => 1,
+                'max_redirects' => 5,
+            ],
+        ]);
+
+        $body = @file_get_contents($url, false, $context);
+
+        return $body === false ? null : $body;
+    }
+}

--- a/app/Updater/UpdateCachePath.php
+++ b/app/Updater/UpdateCachePath.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Updater;
+
+class UpdateCachePath
+{
+    public static function default(): string
+    {
+        $xdgCacheHome = getenv('XDG_CACHE_HOME');
+
+        if (is_string($xdgCacheHome) && $xdgCacheHome !== '') {
+            return $xdgCacheHome.'/scotty';
+        }
+
+        $home = getenv('HOME');
+
+        if (! is_string($home) || $home === '') {
+            $home = $_SERVER['HOME'] ?? null;
+        }
+
+        if (! is_string($home) || $home === '') {
+            return sys_get_temp_dir().'/scotty';
+        }
+
+        return $home.'/.cache/scotty';
+    }
+}

--- a/app/Updater/UpdateChecker.php
+++ b/app/Updater/UpdateChecker.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Updater;
+
+use Throwable;
+
+class UpdateChecker
+{
+    public const CACHE_TTL_SECONDS = 86_400;
+
+    /** @var callable(string): ?string */
+    protected $httpFetcher;
+
+    public function __construct(
+        protected string $currentVersion,
+        protected string $cacheDirectory,
+        protected string $latestReleaseUrl = 'https://api.github.com/repos/spatie/scotty/releases/latest',
+        ?callable $httpFetcher = null,
+    ) {
+        $this->httpFetcher = $httpFetcher ?? fn (string $url): ?string => $this->defaultHttpFetcher($url);
+    }
+
+    public function findNewerVersion(): ?string
+    {
+        $latestVersion = $this->fetchLatestVersion();
+
+        if ($latestVersion === null) {
+            return null;
+        }
+
+        if (version_compare($latestVersion, $this->currentVersion, '<=')) {
+            return null;
+        }
+
+        return $latestVersion;
+    }
+
+    protected function fetchLatestVersion(): ?string
+    {
+        $cached = $this->readCache();
+
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        try {
+            $body = ($this->httpFetcher)($this->latestReleaseUrl);
+        } catch (Throwable) {
+            return null;
+        }
+
+        if (! is_string($body) || $body === '') {
+            return null;
+        }
+
+        $payload = json_decode($body, true);
+
+        if (! is_array($payload)) {
+            return null;
+        }
+
+        $tagName = $payload['tag_name'] ?? null;
+
+        if (! is_string($tagName) || $tagName === '') {
+            return null;
+        }
+
+        $version = str_starts_with($tagName, 'v') ? substr($tagName, 1) : $tagName;
+
+        $this->writeCache($version);
+
+        return $version;
+    }
+
+    protected function defaultHttpFetcher(string $url): ?string
+    {
+        $context = stream_context_create([
+            'http' => [
+                'timeout' => 3,
+                'header' => "Accept: application/vnd.github+json\r\nUser-Agent: scotty-self-update\r\n",
+            ],
+        ]);
+
+        $body = @file_get_contents($url, false, $context);
+
+        return $body === false ? null : $body;
+    }
+
+    protected function readCache(): ?string
+    {
+        $cacheFile = $this->cacheFile();
+
+        if (! is_file($cacheFile)) {
+            return null;
+        }
+
+        $age = time() - (int) @filemtime($cacheFile);
+
+        if ($age > self::CACHE_TTL_SECONDS) {
+            return null;
+        }
+
+        $contents = trim((string) @file_get_contents($cacheFile));
+
+        return $contents !== '' ? $contents : null;
+    }
+
+    protected function writeCache(string $version): void
+    {
+        if (! is_dir($this->cacheDirectory)) {
+            @mkdir($this->cacheDirectory, 0755, true);
+        }
+
+        @file_put_contents($this->cacheFile(), $version);
+    }
+
+    protected function cacheFile(): string
+    {
+        return $this->cacheDirectory.'/update-check';
+    }
+}

--- a/app/Updater/UpdateResult.php
+++ b/app/Updater/UpdateResult.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Updater;
+
+final readonly class UpdateResult
+{
+    private function __construct(
+        public bool $succeeded,
+        public ?string $error = null,
+    ) {}
+
+    public static function success(): self
+    {
+        return new self(true);
+    }
+
+    public static function failed(string $error): self
+    {
+        return new self(false, $error);
+    }
+}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,9 +3,11 @@ title: Installation & setup
 weight: 4
 ---
 
-Scotty ships as a single-file phar executable. There are two ways to install it.
+Scotty ships as a single-file phar executable. The phar download is the preferred installation method. Install it once globally, or commit it per project.
 
-## Per project (recommended)
+The phar bundles its own PHP requirements check. If you run it on a PHP version older than 8.4 (or with a missing required extension), Scotty fails fast with a clear error before any task runs.
+
+## Per project
 
 Download the phar from the latest GitHub release and drop it into your project:
 
@@ -19,7 +21,19 @@ Commit the phar to your repository so everyone on the team uses the same version
 
 ## Globally
 
-You can install Scotty as a global Composer package:
+The simplest way to install Scotty globally is to drop the phar somewhere on your `$PATH`:
+
+```bash
+curl -L https://github.com/spatie/scotty/releases/latest/download/scotty -o /usr/local/bin/scotty
+chmod +x /usr/local/bin/scotty
+scotty list
+```
+
+Any directory on your `$PATH` works. Common alternatives are `~/.local/bin` (no `sudo` needed) or `~/bin`.
+
+### Via Composer
+
+You can also install Scotty as a global Composer package:
 
 ```bash
 composer global require spatie/scotty
@@ -31,13 +45,23 @@ Make sure Composer's global bin directory is in your `$PATH`. If you're not sure
 composer global config bin-dir --absolute
 ```
 
-Once installed, you should be able to run:
+> Installing Scotty as a per-project Composer dev dependency (`composer require --dev spatie/scotty`) is not supported. Scotty is a Laravel Zero application and its `illuminate/*` requirements will conflict with the host application's. Use the phar download or the global install instead.
+
+## Updating
+
+Phar installs of Scotty offer to update themselves automatically. After a successful `scotty run`, Scotty checks GitHub for a newer release (once a day, cached locally). If a newer version is available, Scotty asks at the end of the run whether you want to update. The deploy always finishes first, so the prompt never blocks your release.
+
+To update on demand, run:
 
 ```bash
-scotty list
+scotty self-update
 ```
 
-> Installing Scotty as a per-project Composer dev dependency (`composer require --dev spatie/scotty`) is not supported. Scotty is a Laravel Zero application and its `illuminate/*` requirements will conflict with the host application's. Use the phar download or the global install instead.
+This downloads the latest phar and replaces the running binary in place. Pass `--force` to re-download even if you're already on the latest version.
+
+To skip the post-run update check, pass `--no-update-check` to `scotty run` or set `SCOTTY_NO_UPDATE_CHECK=1` (recognized values: `1`, `true`, `yes`, `on`). The check is also skipped automatically when Scotty is running non-interactively (for example in CI).
+
+Composer global installs upgrade with `composer global update spatie/scotty`.
 
 ## Creating your first Scotty file
 

--- a/tests/Unit/SelfUpdaterTest.php
+++ b/tests/Unit/SelfUpdaterTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use App\Updater\SelfUpdater;
+
+beforeEach(function () {
+    $this->workingDirectory = sys_get_temp_dir().'/scotty-self-update-'.uniqid();
+    mkdir($this->workingDirectory, 0755, true);
+
+    $this->pharPath = $this->workingDirectory.'/scotty';
+    file_put_contents($this->pharPath, str_repeat('OLD', 1024));
+    chmod($this->pharPath, 0755);
+});
+
+afterEach(function () {
+    @chmod($this->workingDirectory, 0755);
+
+    foreach (glob($this->workingDirectory.'/*') ?: [] as $file) {
+        @chmod($file, 0644);
+        @unlink($file);
+    }
+
+    @rmdir($this->workingDirectory);
+});
+
+it('replaces the phar with the freshly downloaded contents', function () {
+    $payload = str_repeat('NEW', SelfUpdater::MIN_PHAR_SIZE_BYTES);
+
+    $updater = new SelfUpdater(
+        downloader: fn (): string => $payload,
+    );
+
+    $result = $updater->update('1.4.0', $this->pharPath);
+
+    expect($result->succeeded)->toBeTrue()
+        ->and(file_get_contents($this->pharPath))->toBe($payload);
+});
+
+it('substitutes the version into the download URL template', function () {
+    $receivedUrl = null;
+
+    $updater = new SelfUpdater(
+        downloadUrlTemplate: 'https://example.test/scotty-{version}.phar',
+        downloader: function (string $url) use (&$receivedUrl): string {
+            $receivedUrl = $url;
+
+            return str_repeat('X', SelfUpdater::MIN_PHAR_SIZE_BYTES);
+        },
+    );
+
+    $updater->update('1.4.0', $this->pharPath);
+
+    expect($receivedUrl)->toBe('https://example.test/scotty-1.4.0.phar');
+});
+
+it('returns failure when the download is suspiciously small', function () {
+    $updater = new SelfUpdater(
+        downloader: fn (): string => 'tiny',
+    );
+
+    $result = $updater->update('1.4.0', $this->pharPath);
+
+    expect($result->succeeded)->toBeFalse()
+        ->and($result->error)->toContain('suspiciously small');
+});
+
+it('returns failure when the downloader returns null', function () {
+    $updater = new SelfUpdater(
+        downloader: fn (): ?string => null,
+    );
+
+    $result = $updater->update('1.4.0', $this->pharPath);
+
+    expect($result->succeeded)->toBeFalse()
+        ->and($result->error)->toContain('Download failed');
+});
+
+it('returns failure when the downloader throws', function () {
+    $updater = new SelfUpdater(
+        downloader: function (): string {
+            throw new RuntimeException('boom');
+        },
+    );
+
+    $result = $updater->update('1.4.0', $this->pharPath);
+
+    expect($result->succeeded)->toBeFalse()
+        ->and($result->error)->toContain('boom');
+});
+
+it('refuses to write when the parent directory is not writable', function () {
+    chmod($this->workingDirectory, 0555);
+
+    $updater = new SelfUpdater(
+        downloader: fn (): string => str_repeat('X', SelfUpdater::MIN_PHAR_SIZE_BYTES),
+    );
+
+    $result = $updater->update('1.4.0', $this->pharPath);
+
+    expect($result->succeeded)->toBeFalse()
+        ->and($result->error)->toContain('Cannot write');
+});

--- a/tests/Unit/UpdateCheckerTest.php
+++ b/tests/Unit/UpdateCheckerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use App\Updater\UpdateChecker;
+
+beforeEach(function () {
+    $this->cacheDirectory = sys_get_temp_dir().'/scotty-update-check-'.uniqid();
+});
+
+afterEach(function () {
+    if (is_dir($this->cacheDirectory)) {
+        array_map('unlink', glob($this->cacheDirectory.'/*') ?: []);
+        @rmdir($this->cacheDirectory);
+    }
+});
+
+it('returns the latest tag when newer than the current version', function () {
+    $checker = new UpdateChecker(
+        currentVersion: '1.3.0',
+        cacheDirectory: $this->cacheDirectory,
+        httpFetcher: fn (): string => json_encode(['tag_name' => '1.4.0']),
+    );
+
+    expect($checker->findNewerVersion())->toBe('1.4.0');
+});
+
+it('returns null when the current version is already the latest', function () {
+    $checker = new UpdateChecker(
+        currentVersion: '1.3.0',
+        cacheDirectory: $this->cacheDirectory,
+        httpFetcher: fn (): string => json_encode(['tag_name' => '1.3.0']),
+    );
+
+    expect($checker->findNewerVersion())->toBeNull();
+});
+
+it('strips a leading v from the tag', function () {
+    $checker = new UpdateChecker(
+        currentVersion: '1.3.0',
+        cacheDirectory: $this->cacheDirectory,
+        httpFetcher: fn (): string => json_encode(['tag_name' => 'v1.4.0']),
+    );
+
+    expect($checker->findNewerVersion())->toBe('1.4.0');
+});
+
+it('returns null silently when the request fails', function () {
+    $checker = new UpdateChecker(
+        currentVersion: '1.3.0',
+        cacheDirectory: $this->cacheDirectory,
+        httpFetcher: fn (): ?string => null,
+    );
+
+    expect($checker->findNewerVersion())->toBeNull();
+});
+
+it('returns null silently when the fetcher throws', function () {
+    $checker = new UpdateChecker(
+        currentVersion: '1.3.0',
+        cacheDirectory: $this->cacheDirectory,
+        httpFetcher: function (): string {
+            throw new RuntimeException('network down');
+        },
+    );
+
+    expect($checker->findNewerVersion())->toBeNull();
+});
+
+it('returns null when the response is not valid JSON', function () {
+    $checker = new UpdateChecker(
+        currentVersion: '1.3.0',
+        cacheDirectory: $this->cacheDirectory,
+        httpFetcher: fn (): string => 'not json at all',
+    );
+
+    expect($checker->findNewerVersion())->toBeNull();
+});
+
+it('caches the latest version and reuses it on subsequent calls', function () {
+    $callCount = 0;
+
+    $checker = new UpdateChecker(
+        currentVersion: '1.3.0',
+        cacheDirectory: $this->cacheDirectory,
+        httpFetcher: function () use (&$callCount): string {
+            $callCount++;
+
+            return json_encode(['tag_name' => '1.4.0']);
+        },
+    );
+
+    $checker->findNewerVersion();
+    $checker->findNewerVersion();
+
+    expect($callCount)->toBe(1);
+});
+
+it('ignores stale cache entries', function () {
+    if (! is_dir($this->cacheDirectory)) {
+        mkdir($this->cacheDirectory, 0755, true);
+    }
+
+    $cacheFile = $this->cacheDirectory.'/update-check';
+    file_put_contents($cacheFile, '1.3.5');
+    touch($cacheFile, time() - UpdateChecker::CACHE_TTL_SECONDS - 60);
+
+    $checker = new UpdateChecker(
+        currentVersion: '1.3.0',
+        cacheDirectory: $this->cacheDirectory,
+        httpFetcher: fn (): string => json_encode(['tag_name' => '1.5.0']),
+    );
+
+    expect($checker->findNewerVersion())->toBe('1.5.0');
+});


### PR DESCRIPTION
## Summary

After a successful `scotty run` from a phar install, Scotty now offers to update itself if a newer release is available on GitHub. The deploy always finishes first, so the prompt never blocks the release.

Adds:
- A new `scotty self-update` command for on-demand updates (with `--force` to re-download even when up to date).
- A `--no-update-check` flag on `scotty run` and a `SCOTTY_NO_UPDATE_CHECK` env var (`1`/`true`/`yes`/`on`) to opt out.
- 24h GitHub API cache at `~/.cache/scotty/update-check` (respects `XDG_CACHE_HOME`).
- Network failures during the check are completely silent — nothing is shown if `api.github.com` is unreachable.
- Skipped automatically when not interactive (CI), when not running from a phar, when the previous run failed, or when STDIN/STDOUT isn't a TTY.

Includes the docs additions from #10 (now superseded), plus a new "Updating" section covering `self-update`, the auto-prompt behavior, and how to opt out.

Note: the phar already validates PHP version requirements at startup via Box's built-in checker (PHP `^8.4` and required extensions), so an update downloaded onto a too-old PHP install errors clearly instead of silently breaking.