### PR TITLE
Evaluate top-level bash preamble once locally

### DIFF
--- a/app/Execution/EvaluatedPreamble.php
+++ b/app/Execution/EvaluatedPreamble.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Execution;
+
+class EvaluatedPreamble
+{
+    /** @param array<string, string> $variables */
+    public function __construct(
+        public readonly array $variables,
+        public readonly string $remainingPreamble,
+    ) {}
+}

--- a/app/Execution/Executor.php
+++ b/app/Execution/Executor.php
@@ -12,6 +12,7 @@ class Executor
 {
     public function __construct(
         protected TaskRunner $taskRunner = new TaskRunner,
+        protected PreambleEvaluator $preambleEvaluator = new PreambleEvaluator,
     ) {}
 
     /**
@@ -86,23 +87,40 @@ class Executor
 
     /**
      * @param  array<TaskDefinition>  $tasks
+     * @param  array<string, string>  $env
      * @return array<TaskDefinition>
      */
     protected function prependVariables(array $tasks, ParseResult $config, array $env): array
     {
-        $preamble = $config->variablePreamble;
+        $evaluated = $this->preambleEvaluator->evaluate(
+            $config->variablePreamble,
+            $this->buildEnvForPreamble($env),
+        );
 
-        $seen = [];
+        $assignments = $evaluated->variables;
 
         foreach ($env as $key => $value) {
             $upperKey = strtoupper(str_replace('-', '_', $key));
 
-            if (isset($seen[$upperKey])) {
+            if (isset($assignments[$upperKey])) {
                 continue;
             }
 
-            $seen[$upperKey] = true;
-            $preamble .= "\n{$upperKey}=".escapeshellarg($value);
+            $assignments[$upperKey] = $value;
+        }
+
+        $assignmentLines = [];
+
+        foreach ($assignments as $name => $value) {
+            $assignmentLines[] = "{$name}=".escapeshellarg($value);
+        }
+
+        $preamble = implode("\n", $assignmentLines);
+
+        if ($evaluated->remainingPreamble !== '') {
+            $preamble = $preamble === ''
+                ? $evaluated->remainingPreamble
+                : "{$preamble}\n\n{$evaluated->remainingPreamble}";
         }
 
         $debugTrap = "trap 'echo \"ENVOY_TRACE:\$BASH_COMMAND\" >&2' DEBUG";
@@ -118,6 +136,22 @@ class Executor
             confirm: $task->confirm,
             emoji: $task->emoji,
         ), $tasks);
+    }
+
+    /**
+     * @param  array<string, string>  $env
+     * @return array<string, string>
+     */
+    protected function buildEnvForPreamble(array $env): array
+    {
+        $result = [];
+
+        foreach ($env as $key => $value) {
+            $upperKey = strtoupper(str_replace('-', '_', $key));
+            $result[$upperKey] = $value;
+        }
+
+        return $result;
     }
 
     protected function pretendTask(TaskDefinition $task, ParseResult $config, array $env): TaskResult

--- a/app/Execution/PreambleEvaluator.php
+++ b/app/Execution/PreambleEvaluator.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Execution;
+
+use RuntimeException;
+use Symfony\Component\Process\Process;
+
+class PreambleEvaluator
+{
+    protected const VARS_BEGIN_MARKER = '__SCOTTY_PREAMBLE_VARS_BEGIN__';
+
+    protected const VARS_END_MARKER = '__SCOTTY_PREAMBLE_VARS_END__';
+
+    /** @param array<string, string> $env */
+    public function evaluate(string $preamble, array $env = []): EvaluatedPreamble
+    {
+        $variableNames = $this->extractVariableNames($preamble);
+
+        if ($variableNames === []) {
+            return new EvaluatedPreamble([], $preamble);
+        }
+
+        $values = $this->captureVariableValues($preamble, $variableNames, $env);
+        $remaining = $this->stripVariableAssignments($preamble);
+
+        return new EvaluatedPreamble($values, $remaining);
+    }
+
+    /** @return array<string> */
+    protected function extractVariableNames(string $preamble): array
+    {
+        preg_match_all('/^\s*([A-Z_][A-Z0-9_]*)=/m', $preamble, $matches);
+
+        return array_values(array_unique($matches[1]));
+    }
+
+    /**
+     * @param  array<string>  $variableNames
+     * @param  array<string, string>  $env
+     * @return array<string, string>
+     */
+    protected function captureVariableValues(string $preamble, array $variableNames, array $env): array
+    {
+        $dumpLines = '';
+
+        foreach ($variableNames as $name) {
+            $dumpLines .= "printf '%s=%s\\n' ".escapeshellarg($name)." \"\${{$name}}\"\n";
+        }
+
+        $script = "set -e\n"
+            .$preamble."\n"
+            .'echo '.escapeshellarg(self::VARS_BEGIN_MARKER)."\n"
+            .$dumpLines
+            .'echo '.escapeshellarg(self::VARS_END_MARKER)."\n";
+
+        $process = new Process(['bash', '-c', $script]);
+        $process->setEnv($env);
+        $process->setTimeout(60);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            $message = trim($process->getErrorOutput()) ?: trim($process->getOutput());
+
+            throw new RuntimeException("Failed to evaluate preamble locally: {$message}");
+        }
+
+        return $this->parseVariableDump($process->getOutput(), $variableNames);
+    }
+
+    /**
+     * @param  array<string>  $variableNames
+     * @return array<string, string>
+     */
+    protected function parseVariableDump(string $output, array $variableNames): array
+    {
+        $startPosition = strpos($output, self::VARS_BEGIN_MARKER);
+        $endPosition = strpos($output, self::VARS_END_MARKER);
+
+        if ($startPosition === false || $endPosition === false || $endPosition < $startPosition) {
+            throw new RuntimeException('Preamble output is missing the variable markers.');
+        }
+
+        $section = substr(
+            $output,
+            $startPosition + strlen(self::VARS_BEGIN_MARKER),
+            $endPosition - $startPosition - strlen(self::VARS_BEGIN_MARKER),
+        );
+
+        $values = [];
+
+        foreach (explode("\n", $section) as $line) {
+            if (! preg_match('/^([A-Z_][A-Z0-9_]*)=(.*)$/', $line, $match)) {
+                continue;
+            }
+
+            if (! in_array($match[1], $variableNames, true)) {
+                continue;
+            }
+
+            $values[$match[1]] = $match[2];
+        }
+
+        return $values;
+    }
+
+    protected function stripVariableAssignments(string $preamble): string
+    {
+        $lines = explode("\n", $preamble);
+        $kept = [];
+
+        foreach ($lines as $line) {
+            if (preg_match('/^\s*[A-Z_][A-Z0-9_]*=/', $line)) {
+                continue;
+            }
+
+            $kept[] = $line;
+        }
+
+        return trim(implode("\n", $kept));
+    }
+}

--- a/docs/basic-usage/bash-format.md
+++ b/docs/basic-usage/bash-format.md
@@ -120,6 +120,10 @@ NEW_RELEASE_NAME=$(date +%Y%m%d-%H%M%S)
 
 These are plain bash variables, so computed values like `$(date)` work naturally. All variables are available in all tasks.
 
+Top-level variable assignments are evaluated **once locally** before the first task runs. The captured values are then injected into every task's script. This means a value like `NEW_RELEASE_NAME=$(date +%Y%m%d-%H%M%S)` produces the same timestamp in every task of the same run, which is what you want for zero-downtime deploys where multiple tasks need to agree on a release directory.
+
+Helper functions defined at the top of the file still run inside each task on the remote server. Side effects in top-level assignments (`mkdir`, `rm`, etc.) happen on your local machine, not on the remote. If you need work to happen remotely, put it in a task.
+
 You can also accept variables from the command line by declaring them with `# @option`. Three forms are supported:
 
 ```bash

--- a/tests/Feature/RunCommandTest.php
+++ b/tests/Feature/RunCommandTest.php
@@ -181,6 +181,46 @@ BASH);
     }
 });
 
+it('evaluates the preamble locally once so dynamic values stay stable across tasks in a macro', function () {
+    $fixture = $this->fixturePath.'/zero-downtime.sh';
+    file_put_contents($fixture, <<<'BASH'
+# @servers local=127.0.0.1
+
+NEW_RELEASE_NAME=$(date "+%Y%m%d-%H%M%S%N")
+NEW_RELEASE_DIR="app/${NEW_RELEASE_NAME}"
+
+# @macro release test_start test_end
+
+# @task on:local
+test_start() {
+    echo "${NEW_RELEASE_DIR}"
+}
+
+# @task on:local
+test_end() {
+    echo "${NEW_RELEASE_DIR}"
+}
+BASH);
+
+    try {
+        Artisan::call('run', [
+            'task' => 'release',
+            '--pretend' => true,
+            '--conf' => $fixture,
+        ]);
+
+        $output = Artisan::output();
+
+        preg_match_all("/NEW_RELEASE_NAME='([^']+)'/", $output, $matches);
+
+        expect($matches[1])->toHaveCount(2)
+            ->and($matches[1][0])->toBe($matches[1][1])
+            ->and($output)->toContain("NEW_RELEASE_DIR='app/{$matches[1][0]}'");
+    } finally {
+        @unlink($fixture);
+    }
+});
+
 it('exposes dashed option names as snake_case uppercase env vars', function () {
     $fixture = $this->fixturePath.'/dashed-options.sh';
     file_put_contents($fixture, <<<'BASH'

--- a/tests/Unit/PreambleEvaluatorTest.php
+++ b/tests/Unit/PreambleEvaluatorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Execution\PreambleEvaluator;
+
+it('returns the preamble unchanged when there are no variable assignments', function () {
+    $preamble = "format_date() {\n    date +\"%Y-%m-%d\"\n}";
+
+    $result = (new PreambleEvaluator)->evaluate($preamble);
+
+    expect($result->variables)->toBe([])
+        ->and($result->remainingPreamble)->toBe($preamble);
+});
+
+it('captures simple string assignments locally', function () {
+    $preamble = 'BRANCH="main"';
+
+    $result = (new PreambleEvaluator)->evaluate($preamble);
+
+    expect($result->variables)->toBe(['BRANCH' => 'main'])
+        ->and($result->remainingPreamble)->toBe('');
+});
+
+it('evaluates command substitutions once and freezes the value', function () {
+    $preamble = 'TIMESTAMP=$(date +%s)';
+
+    $evaluator = new PreambleEvaluator;
+
+    $first = $evaluator->evaluate($preamble);
+    sleep(1);
+    $second = $evaluator->evaluate($preamble);
+
+    expect($first->variables['TIMESTAMP'])->not->toBe($second->variables['TIMESTAMP']);
+
+    expect((int) $first->variables['TIMESTAMP'])
+        ->toBeGreaterThan(0)
+        ->toBeLessThan((int) $second->variables['TIMESTAMP']);
+});
+
+it('captures variables that depend on each other', function () {
+    $preamble = "RELEASE_NAME=20260427-145000\nRELEASE_DIR=\"app/\${RELEASE_NAME}\"";
+
+    $result = (new PreambleEvaluator)->evaluate($preamble);
+
+    expect($result->variables)->toBe([
+        'RELEASE_NAME' => '20260427-145000',
+        'RELEASE_DIR' => 'app/20260427-145000',
+    ]);
+});
+
+it('keeps helper functions in the remaining preamble', function () {
+    $preamble = "BRANCH=main\n\nformat_date() {\n    date +\"%Y-%m-%d\"\n}";
+
+    $result = (new PreambleEvaluator)->evaluate($preamble);
+
+    expect($result->variables)->toBe(['BRANCH' => 'main'])
+        ->and($result->remainingPreamble)->toContain('format_date()')
+        ->and($result->remainingPreamble)->not->toContain('BRANCH=');
+});
+
+it('passes provided env variables to the preamble execution', function () {
+    $preamble = 'TARGET="${BRANCH}-build"';
+
+    $result = (new PreambleEvaluator)->evaluate($preamble, ['BRANCH' => 'develop']);
+
+    expect($result->variables)->toBe(['TARGET' => 'develop-build']);
+});
+
+it('throws when the preamble exits with a non-zero status', function () {
+    $preamble = "VAR=valid\nfalse";
+
+    expect(fn () => (new PreambleEvaluator)->evaluate($preamble))
+        ->toThrow(RuntimeException::class, 'Failed to evaluate preamble');
+});


### PR DESCRIPTION
## Summary

Fixes #6. Top-level variable assignments in a Scotty.sh file are now evaluated **once locally** before any task runs. The captured values are injected as literal assignments into every task's script. This means `NEW_RELEASE_NAME=\$(date +%Y%m%d-%H%M%S)` produces the same timestamp across every task in a single run, which is what zero-downtime deploys need.

Previously the entire preamble was sent to the remote server as part of each task's script. Each SSH session re-evaluated `\$(date)`, so two tasks in a macro saw different release directories.

## Behavior change

This is intentional. The bash format now matches what Blade `@setup` already does: top-level work runs once on the orchestrator, not per task.

- Top-level `UPPER_SNAKE_CASE=...` assignments evaluate locally, once.
- Helper functions (and any other lines) still get sent to the remote server inside each task's script, since they need to be available there.
- Side effects in top-level assignments (`mkdir`, `rm`, etc.) now happen on the local machine. If you need work to happen remotely, put it in a task.
- If the preamble exits non-zero, Scotty errors out before any task runs.

We don't have many users yet, so taking the cleaner break now rather than introducing a new directive.

## Implementation

- `App\Execution\PreambleEvaluator` runs the preamble through a local `bash -c` once, asks bash to dump the resulting values for the variable names parsed out of the preamble, and returns `(captured values, remaining preamble)`.
- `Executor::prependVariables` swaps the dynamic preamble for literal assignments + the remaining preamble (helper functions etc.).
- Tests cover string assignments, command substitution, mutually-dependent vars, helper-function preservation, env passthrough, and non-zero-exit failure.
- A feature test runs a macro that prints `\$NEW_RELEASE_DIR` from two tasks and asserts the values match.