### PR TITLE
Apply Spatie PHP guidelines across the codebase

### DIFF
--- a/app/Commands/Concerns/ResolvesScottyFile.php
+++ b/app/Commands/Concerns/ResolvesScottyFile.php
@@ -24,7 +24,9 @@ trait ResolvesScottyFile
 
     protected function resolveFilePath(): ?string
     {
-        if ($path = $this->option('path')) {
+        $path = $this->option('path');
+
+        if ($path) {
             return file_exists($path) ? $path : null;
         }
 

--- a/app/Commands/DoctorCommand.php
+++ b/app/Commands/DoctorCommand.php
@@ -264,66 +264,20 @@ class DoctorCommand extends Command
         $output = trim($process->getOutput());
         $lines = $output !== '' ? explode("\n", $output) : [];
 
-        $this->reportToolVersion('php', $this->extractPhpVersion($lines));
-        $this->reportToolVersion('composer', $this->extractComposerVersion($lines));
-        $this->reportToolVersion('node', $this->extractNodeVersion($lines));
-        $this->reportToolVersion('npm', $this->extractNpmVersion($lines));
-        $this->reportToolVersion('git', $this->extractGitVersion($lines));
+        $this->reportToolVersion('php', $this->extractVersion($lines, '/^PHP (\d+\.\d+\.\d+)/'));
+        $this->reportToolVersion('composer', $this->extractVersion($lines, '/Composer.*?(\d+\.\d+\.\d+)/'));
+        $this->reportToolVersion('node', $this->extractVersion($lines, '/^v(\d+\.\d+\.\d+)/'));
+        $this->reportToolVersion('npm', $this->extractVersion($lines, '/^(\d+\.\d+\.\d+)$/', trimLine: true));
+        $this->reportToolVersion('git', $this->extractVersion($lines, '/git version (\d+\.\d+\.\d+)/'));
     }
 
     /** @param array<string> $lines */
-    protected function extractPhpVersion(array $lines): ?string
+    protected function extractVersion(array $lines, string $pattern, bool $trimLine = false): ?string
     {
         foreach ($lines as $line) {
-            if (preg_match('/^PHP (\d+\.\d+\.\d+)/', $line, $matches)) {
-                return $matches[1];
-            }
-        }
+            $candidate = $trimLine ? trim($line) : $line;
 
-        return null;
-    }
-
-    /** @param array<string> $lines */
-    protected function extractComposerVersion(array $lines): ?string
-    {
-        foreach ($lines as $line) {
-            if (preg_match('/Composer.*?(\d+\.\d+\.\d+)/', $line, $matches)) {
-                return $matches[1];
-            }
-        }
-
-        return null;
-    }
-
-    /** @param array<string> $lines */
-    protected function extractNodeVersion(array $lines): ?string
-    {
-        foreach ($lines as $line) {
-            if (preg_match('/^v(\d+\.\d+\.\d+)/', $line, $matches)) {
-                return $matches[1];
-            }
-        }
-
-        return null;
-    }
-
-    /** @param array<string> $lines */
-    protected function extractNpmVersion(array $lines): ?string
-    {
-        foreach ($lines as $line) {
-            if (preg_match('/^(\d+\.\d+\.\d+)$/', trim($line), $matches)) {
-                return $matches[1];
-            }
-        }
-
-        return null;
-    }
-
-    /** @param array<string> $lines */
-    protected function extractGitVersion(array $lines): ?string
-    {
-        foreach ($lines as $line) {
-            if (preg_match('/git version (\d+\.\d+\.\d+)/', $line, $matches)) {
+            if (preg_match($pattern, $candidate, $matches)) {
                 return $matches[1];
             }
         }

--- a/app/Commands/RunCommand.php
+++ b/app/Commands/RunCommand.php
@@ -11,6 +11,8 @@ use App\Parsing\TaskDefinition;
 use App\Updater\SelfUpdater;
 use App\Updater\UpdateCachePath;
 use App\Updater\UpdateChecker;
+use DateTime;
+use DateTimeZone;
 use LaravelZero\Framework\Commands\Command;
 use Phar;
 use Symfony\Component\Console\Input\InputInterface;
@@ -546,7 +548,7 @@ class RunCommand extends Command
 
         $input = @fread(STDIN, 1);
 
-        if (! in_array($input, ['p', 'P'])) {
+        if (! in_array($input, ['p', 'P'], true)) {
             return;
         }
 
@@ -629,18 +631,26 @@ class RunCommand extends Command
 
     protected function currentLocalTime(): string
     {
-        $timezone = null;
+        $timezone = $this->detectSystemTimezone();
 
+        return (new DateTime('now', new DateTimeZone($timezone)))->format('H:i:s');
+    }
+
+    protected function detectSystemTimezone(): string
+    {
         $localtime = @readlink('/etc/localtime');
+
         if ($localtime && preg_match('#zoneinfo/(.+)$#', $localtime, $matches)) {
-            $timezone = $matches[1];
+            return $matches[1];
         }
 
-        if (! $timezone) {
-            $timezone = trim((string) shell_exec('date +%z'));
+        $offset = trim((string) shell_exec('date +%z'));
+
+        if ($offset !== '') {
+            return $offset;
         }
 
-        return (new \DateTime('now', new \DateTimeZone($timezone ?: 'UTC')))->format('H:i:s');
+        return 'UTC';
     }
 
     protected function cleanOutputLine(string $line): string
@@ -721,35 +731,17 @@ class RunCommand extends Command
         foreach ($declared as $option) {
             $key = $option->name;
             $snakeCase = str_replace('-', '_', $key);
-            $envKey = strtoupper($snakeCase);
 
-            if ($option->isBoolean) {
-                if (! $this->option($key)) {
-                    continue;
-                }
+            $value = $this->resolveOptionValue($option, $snakeCase);
 
-                $value = '1';
-            } else {
-                $cliPassed = $this->input->hasParameterOption(['--'.$key], true);
-                $envValue = getenv($envKey);
+            if ($option->isRequired && ($value === null || $value === '')) {
+                error("Missing required option --{$key}. Declare a default with `# @option {$key}=value` or pass `--{$key}=...`.");
 
-                if ($cliPassed) {
-                    $value = $this->option($key);
-                } elseif ($envValue !== false && $envValue !== '') {
-                    $value = $envValue;
-                } else {
-                    $value = $option->default;
-                }
+                return null;
+            }
 
-                if ($option->isRequired && ($value === null || $value === '')) {
-                    error("Missing required option --{$key}. Declare a default with `# @option {$key}=value` or pass `--{$key}=...`.");
-
-                    return null;
-                }
-
-                if ($value === null) {
-                    continue;
-                }
+            if ($value === null) {
+                continue;
             }
 
             $camelCase = lcfirst(str_replace(' ', '', ucwords(str_replace('-', ' ', $key))));
@@ -760,6 +752,27 @@ class RunCommand extends Command
         }
 
         return $data;
+    }
+
+    protected function resolveOptionValue(OptionDefinition $option, string $snakeCase): ?string
+    {
+        $key = $option->name;
+
+        if ($option->isBoolean) {
+            return $this->option($key) ? '1' : null;
+        }
+
+        if ($this->input->hasParameterOption(["--{$key}"], true)) {
+            return $this->option($key);
+        }
+
+        $envValue = getenv(strtoupper($snakeCase));
+
+        if ($envValue !== false && $envValue !== '') {
+            return $envValue;
+        }
+
+        return $option->default;
     }
 
     protected function showAvailableTargets(ParseResult $config): void

--- a/app/Commands/SelfUpdateCommand.php
+++ b/app/Commands/SelfUpdateCommand.php
@@ -38,10 +38,12 @@ class SelfUpdateCommand extends Command
 
         $newerVersion = $checker->findNewerVersion();
 
-        if ($newerVersion === null && ! $this->option('force')) {
-            info("You're already on the latest version ({$currentVersion}).");
+        if ($newerVersion === null) {
+            if (! $this->option('force')) {
+                info("You're already on the latest version ({$currentVersion}).");
 
-            return 0;
+                return 0;
+            }
         }
 
         $targetVersion = $newerVersion ?? $currentVersion;

--- a/app/Commands/SshCommand.php
+++ b/app/Commands/SshCommand.php
@@ -3,6 +3,7 @@
 namespace App\Commands;
 
 use App\Commands\Concerns\ResolvesScottyFile;
+use App\Parsing\ParseResult;
 use App\Parsing\ServerDefinition;
 use LaravelZero\Framework\Commands\Command;
 
@@ -28,17 +29,37 @@ class SshCommand extends Command
             return 1;
         }
 
-        $parser = $this->resolveParser($filePath);
-        $config = $parser->parse($filePath);
+        $config = $this->resolveParser($filePath)->parse($filePath);
 
-        $servers = $config->servers;
-
-        if ($servers === []) {
+        if ($config->servers === []) {
             error('No servers defined.');
 
             return 1;
         }
 
+        $hostOptions = $this->buildHostOptions($config->servers);
+
+        $name = $this->argument('name');
+
+        $host = $name !== null
+            ? $this->resolveHostByServerName($config, $name, $hostOptions)
+            : $this->promptForRemoteHost($hostOptions);
+
+        if ($host === null) {
+            return 1;
+        }
+
+        passthru("ssh {$host}");
+
+        return 0;
+    }
+
+    /**
+     * @param  array<string, ServerDefinition>  $servers
+     * @return array<string, string>
+     */
+    protected function buildHostOptions(array $servers): array
+    {
         $hostOptions = [];
 
         foreach ($servers as $server) {
@@ -47,50 +68,66 @@ class SshCommand extends Command
             }
         }
 
-        $name = $this->argument('name');
+        return $hostOptions;
+    }
 
-        if ($name !== null) {
-            $server = $config->getServer($name);
+    /** @param array<string, string> $hostOptions */
+    protected function resolveHostByServerName(ParseResult $config, string $name, array $hostOptions): ?string
+    {
+        $server = $config->getServer($name);
 
-            if ($server === null) {
-                error("Server \"{$name}\" is not defined.");
+        if ($server === null) {
+            error("Server \"{$name}\" is not defined.");
 
-                return 1;
-            }
-
-            if ($server->isLocal()) {
-                error('Cannot SSH into local server.');
-
-                return 1;
-            }
-
-            $host = count($server->hosts) === 1
-                ? $server->hosts[0]
-                : $hostOptions[select(
-                    label: 'Which host?',
-                    options: array_keys(array_filter($hostOptions, fn ($h) => in_array($h, $server->hosts))),
-                )];
-        } else {
-            $remoteOptions = array_filter($hostOptions, fn ($host) => ! ServerDefinition::isLocalHost($host));
-
-            if ($remoteOptions === []) {
-                error('No remote servers defined.');
-
-                return 1;
-            }
-
-            $selected = count($remoteOptions) === 1
-                ? array_key_first($remoteOptions)
-                : select(
-                    label: 'Which server?',
-                    options: array_keys($remoteOptions),
-                );
-
-            $host = $remoteOptions[$selected];
+            return null;
         }
 
-        passthru("ssh {$host}");
+        if ($server->isLocal()) {
+            error('Cannot SSH into local server.');
 
-        return 0;
+            return null;
+        }
+
+        if (count($server->hosts) === 1) {
+            return $server->hosts[0];
+        }
+
+        $serverHostOptions = array_filter(
+            $hostOptions,
+            fn (string $host) => in_array($host, $server->hosts, true),
+        );
+
+        $selected = select(
+            label: 'Which host?',
+            options: array_keys($serverHostOptions),
+        );
+
+        return $hostOptions[$selected];
+    }
+
+    /** @param array<string, string> $hostOptions */
+    protected function promptForRemoteHost(array $hostOptions): ?string
+    {
+        $remoteOptions = array_filter(
+            $hostOptions,
+            fn (string $host) => ! ServerDefinition::isLocalHost($host),
+        );
+
+        if ($remoteOptions === []) {
+            error('No remote servers defined.');
+
+            return null;
+        }
+
+        if (count($remoteOptions) === 1) {
+            return $remoteOptions[array_key_first($remoteOptions)];
+        }
+
+        $selected = select(
+            label: 'Which server?',
+            options: array_keys($remoteOptions),
+        );
+
+        return $remoteOptions[$selected];
     }
 }

--- a/app/Commands/TasksCommand.php
+++ b/app/Commands/TasksCommand.php
@@ -3,6 +3,7 @@
 namespace App\Commands;
 
 use App\Commands\Concerns\ResolvesScottyFile;
+use App\Parsing\ParseResult;
 use LaravelZero\Framework\Commands\Command;
 
 class TasksCommand extends Command
@@ -23,56 +24,60 @@ class TasksCommand extends Command
             return 1;
         }
 
-        $parser = $this->resolveParser($filePath);
-        $config = $parser->parse($filePath);
-
+        $config = $this->resolveParser($filePath)->parse($filePath);
         $available = $config->availableTargets();
 
         $this->newLine();
 
         if ($available['macros'] !== []) {
-            $this->output->writeln('  <options=bold>Macros</>');
-            $this->newLine();
-
-            foreach ($available['macros'] as $name) {
-                $macro = $config->getMacro($name);
-                $taskList = array_map(function (string $taskName) use ($config) {
-                    $task = $config->getTask($taskName);
-
-                    if ($task === null) {
-                        return $taskName;
-                    }
-
-                    return $task->displayNameWithEmoji();
-                }, $macro->tasks);
-
-                $this->output->writeln("  <fg=green>{$name}</>");
-
-                foreach ($taskList as $index => $taskDisplay) {
-                    $number = $index + 1;
-                    $this->output->writeln("    <fg=#4A5568>{$number}.</> {$taskDisplay}");
-                }
-
-                $this->newLine();
-            }
+            $this->renderMacros($config, $available['macros']);
         }
 
         if ($available['tasks'] !== []) {
-            $this->output->writeln('  <options=bold>Tasks</>');
-            $this->newLine();
+            $this->renderTasks($config, $available['tasks']);
+        }
 
-            foreach ($available['tasks'] as $name) {
-                $task = $config->getTask($name);
-                $servers = implode(', ', $task->servers);
-                $parallel = $task->parallel ? ' <fg=cyan>parallel</>' : '';
-                $displayName = $task->displayNameWithEmoji();
+        return 0;
+    }
 
-                $this->output->writeln("  {$displayName}  <fg=#4A5568>on {$servers}</>{$parallel}");
+    /** @param array<string> $macroNames */
+    protected function renderMacros(ParseResult $config, array $macroNames): void
+    {
+        $this->output->writeln('  <options=bold>Macros</>');
+        $this->newLine();
+
+        foreach ($macroNames as $name) {
+            $macro = $config->getMacro($name);
+
+            $this->output->writeln("  <fg=green>{$name}</>");
+
+            foreach ($macro->tasks as $index => $taskName) {
+                $task = $config->getTask($taskName);
+                $taskDisplay = $task !== null ? $task->displayNameWithEmoji() : $taskName;
+                $number = $index + 1;
+
+                $this->output->writeln("    <fg=#4A5568>{$number}.</> {$taskDisplay}");
             }
 
             $this->newLine();
         }
+    }
 
-        return 0;
+    /** @param array<string> $taskNames */
+    protected function renderTasks(ParseResult $config, array $taskNames): void
+    {
+        $this->output->writeln('  <options=bold>Tasks</>');
+        $this->newLine();
+
+        foreach ($taskNames as $name) {
+            $task = $config->getTask($name);
+            $servers = implode(', ', $task->servers);
+            $parallel = $task->parallel ? ' <fg=cyan>parallel</>' : '';
+            $displayName = $task->displayNameWithEmoji();
+
+            $this->output->writeln("  {$displayName}  <fg=#4A5568>on {$servers}</>{$parallel}");
+        }
+
+        $this->newLine();
     }
 }

--- a/app/Execution/Executor.php
+++ b/app/Execution/Executor.php
@@ -154,6 +154,7 @@ class Executor
         return $result;
     }
 
+    /** @param array<string, string> $env */
     protected function pretendTask(TaskDefinition $task, ParseResult $config, array $env): TaskResult
     {
         $commandBuilder = $this->taskRunner->getCommandBuilder();

--- a/app/Execution/TaskRunner.php
+++ b/app/Execution/TaskRunner.php
@@ -62,10 +62,12 @@ class TaskRunner
 
             if (count($server->hosts) === 1) {
                 $map[$serverName] = $server->hosts[0];
-            } else {
-                foreach ($server->hosts as $host) {
-                    $map[$host] = $host;
-                }
+
+                continue;
+            }
+
+            foreach ($server->hosts as $host) {
+                $map[$host] = $host;
             }
         }
 

--- a/app/Parsing/BashParser.php
+++ b/app/Parsing/BashParser.php
@@ -43,12 +43,14 @@ class BashParser implements ParserInterface
     {
         $servers = [];
 
-        if (preg_match('/^#\s*@servers\s+(.+)$/m', $content, $match)) {
-            preg_match_all('/(\w+)=(\S+)/', $match[1], $pairs, PREG_SET_ORDER);
+        if (! preg_match('/^#\s*@servers\s+(.+)$/m', $content, $match)) {
+            return $servers;
+        }
 
-            foreach ($pairs as $pair) {
-                $servers[$pair[1]] = new ServerDefinition($pair[1], $pair[2]);
-            }
+        preg_match_all('/(\w+)=(\S+)/', $match[1], $pairs, PREG_SET_ORDER);
+
+        foreach ($pairs as $pair) {
+            $servers[$pair[1]] = new ServerDefinition($pair[1], $pair[2]);
         }
 
         return $servers;
@@ -89,10 +91,7 @@ class BashParser implements ParserInterface
             $name = $match[1];
             $taskLines = explode("\n", trim($match[2]));
 
-            $tasks = array_map(function (string $line): string {
-                return trim(ltrim(trim($line), '#'));
-            }, $taskLines);
-
+            $tasks = array_map(fn (string $line): string => trim(ltrim(trim($line), '#')), $taskLines);
             $tasks = array_filter($tasks, fn (string $task) => $task !== '');
 
             $macros[$name] = new MacroDefinition($name, array_values($tasks));
@@ -114,16 +113,13 @@ class BashParser implements ParserInterface
             $bodyStart = $match[0][1] + strlen($match[0][0]);
 
             $script = $this->extractFunctionBody($content, $bodyStart);
-            $servers = $this->parseTaskServers($options);
-            $isParallel = str_contains($options, 'parallel');
-            $confirmMessage = $this->parseTaskConfirm($options);
 
             $tasks[$name] = new TaskDefinition(
                 name: $name,
                 script: $this->dedent($script),
-                servers: $servers,
-                parallel: $isParallel,
-                confirm: $confirmMessage,
+                servers: $this->parseTaskServers($options),
+                parallel: str_contains($options, 'parallel'),
+                confirm: $this->parseTaskConfirm($options),
                 emoji: $this->parseTaskEmoji($options),
             );
         }
@@ -139,16 +135,18 @@ class BashParser implements ParserInterface
         foreach (HookType::cases() as $hookType) {
             $pattern = "/^#\s*@{$hookType->value}\s*\$\n(\w+)\(\)\s*\{/m";
 
-            if (preg_match_all($pattern, $content, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE)) {
-                foreach ($matches as $match) {
-                    $bodyStart = $match[0][1] + strlen($match[0][0]);
-                    $script = $this->extractFunctionBody($content, $bodyStart);
+            if (! preg_match_all($pattern, $content, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE)) {
+                continue;
+            }
 
-                    $hooks[] = new HookDefinition(
-                        type: $hookType,
-                        script: $this->dedent($script),
-                    );
-                }
+            foreach ($matches as $match) {
+                $bodyStart = $match[0][1] + strlen($match[0][0]);
+                $script = $this->extractFunctionBody($content, $bodyStart);
+
+                $hooks[] = new HookDefinition(
+                    type: $hookType,
+                    script: $this->dedent($script),
+                );
             }
         }
 
@@ -166,11 +164,15 @@ class BashParser implements ParserInterface
                 break;
             }
 
-            if ($trimmed === '' || str_starts_with($trimmed, '#') || str_starts_with($trimmed, '#!/')) {
+            if ($trimmed === '') {
                 continue;
             }
 
-            if (preg_match('/^[A-Z_][A-Z0-9_]*=/', $trimmed) || preg_match('/^\w+\(\)\s*\{/', $trimmed)) {
+            if (str_starts_with($trimmed, '#')) {
+                continue;
+            }
+
+            if (preg_match('/^[A-Z_][A-Z0-9_]*=/', $trimmed)) {
                 $lines[] = $line;
             }
         }
@@ -179,11 +181,11 @@ class BashParser implements ParserInterface
 
         $preamble = implode("\n", $lines);
 
-        if ($helperFunctions !== '') {
-            $preamble .= "\n{$helperFunctions}";
+        if ($helperFunctions === '') {
+            return $preamble;
         }
 
-        return $preamble;
+        return "{$preamble}\n{$helperFunctions}";
     }
 
     protected function extractHelperFunctions(string $content): string
@@ -221,31 +223,23 @@ class BashParser implements ParserInterface
         $inDoubleQuote = false;
 
         while ($position < $length && $depth > 0) {
-            $char = $content[$position];
+            $character = $content[$position];
 
-            if ($char === '\\') {
-                if ($inSingleQuote || $inDoubleQuote) {
-                    $position += 2;
+            if ($character === '\\' && ($inSingleQuote || $inDoubleQuote)) {
+                $position += 2;
 
-                    continue;
-                }
+                continue;
             }
 
-            if ($char === "'") {
-                if (! $inDoubleQuote) {
-                    $inSingleQuote = ! $inSingleQuote;
-                }
-            } elseif ($char === '"') {
-                if (! $inSingleQuote) {
-                    $inDoubleQuote = ! $inDoubleQuote;
-                }
-            } elseif (! $inSingleQuote) {
-                if (! $inDoubleQuote) {
-                    if ($char === '{') {
-                        $depth++;
-                    } elseif ($char === '}') {
-                        $depth--;
-                    }
+            if ($character === "'" && ! $inDoubleQuote) {
+                $inSingleQuote = ! $inSingleQuote;
+            } elseif ($character === '"' && ! $inSingleQuote) {
+                $inDoubleQuote = ! $inDoubleQuote;
+            } elseif (! $inSingleQuote && ! $inDoubleQuote) {
+                if ($character === '{') {
+                    $depth++;
+                } elseif ($character === '}') {
+                    $depth--;
                 }
             }
 
@@ -260,29 +254,29 @@ class BashParser implements ParserInterface
     /** @return array<string> */
     protected function parseTaskServers(string $options): array
     {
-        if (preg_match('/on:(\S+)/', $options, $match)) {
-            return explode(',', $match[1]);
+        if (! preg_match('/on:(\S+)/', $options, $match)) {
+            return [];
         }
 
-        return [];
+        return explode(',', $match[1]);
     }
 
     protected function parseTaskConfirm(string $options): ?string
     {
-        if (preg_match('/confirm="([^"]+)"/', $options, $match)) {
-            return $match[1];
+        if (! preg_match('/confirm="([^"]+)"/', $options, $match)) {
+            return null;
         }
 
-        return null;
+        return $match[1];
     }
 
     protected function parseTaskEmoji(string $options): ?string
     {
-        if (preg_match('/emoji:(\S+)/', $options, $match)) {
-            return $match[1];
+        if (! preg_match('/emoji:(\S+)/', $options, $match)) {
+            return null;
         }
 
-        return null;
+        return $match[1];
     }
 
     protected function dedent(string $text): string

--- a/app/Parsing/Blade/Compiler.php
+++ b/app/Parsing/Blade/Compiler.php
@@ -78,11 +78,6 @@ class Compiler
 
     protected function compileEchos(string $value): string
     {
-        return $this->compileRegularEchos($value);
-    }
-
-    protected function compileRegularEchos(string $value): string
-    {
         $pattern = sprintf('/(@)?%s\s*(.+?)\s*%s(\r?\n)?/s', '{{', '}}');
 
         $callback = function (array $matches): string {

--- a/app/Parsing/Blade/TaskContainer.php
+++ b/app/Parsing/Blade/TaskContainer.php
@@ -59,6 +59,7 @@ class TaskContainer
         $this->load($path, $compiler, [], __serversOnly: true);
     }
 
+    /** @param array<string, mixed> $__data */
     public function load(string $__path, Compiler $__compiler, array $__data = [], bool $__serversOnly = false): void
     {
         $__envoyPath = $this->writeCompiledEnvoyFile($__compiler, $__path, $__serversOnly);

--- a/app/Parsing/BladeParser.php
+++ b/app/Parsing/BladeParser.php
@@ -100,8 +100,6 @@ class BladeParser implements ParserInterface
     /** @return array<HookDefinition> */
     protected function buildHooks(TaskContainer $container): array
     {
-        $hooks = [];
-
         $hookMapping = [
             [HookType::Before, $container->getBeforeCallbacks()],
             [HookType::After, $container->getAfterCallbacks()],
@@ -109,6 +107,8 @@ class BladeParser implements ParserInterface
             [HookType::Error, $container->getErrorCallbacks()],
             [HookType::Finished, $container->getFinishedCallbacks()],
         ];
+
+        $hooks = [];
 
         foreach ($hookMapping as [$type, $callbacks]) {
             foreach ($callbacks as $callback) {

--- a/app/Parsing/HookDefinition.php
+++ b/app/Parsing/HookDefinition.php
@@ -2,7 +2,7 @@
 
 namespace App\Parsing;
 
-class HookDefinition
+final readonly class HookDefinition
 {
     public function __construct(
         public HookType $type,

--- a/app/Parsing/MacroDefinition.php
+++ b/app/Parsing/MacroDefinition.php
@@ -2,7 +2,7 @@
 
 namespace App\Parsing;
 
-class MacroDefinition
+final readonly class MacroDefinition
 {
     public function __construct(
         public string $name,

--- a/app/Parsing/NotificationDefinition.php
+++ b/app/Parsing/NotificationDefinition.php
@@ -2,7 +2,7 @@
 
 namespace App\Parsing;
 
-class NotificationDefinition
+final readonly class NotificationDefinition
 {
     public function __construct(
         public string $channel,

--- a/app/Parsing/OptionDefinition.php
+++ b/app/Parsing/OptionDefinition.php
@@ -4,7 +4,7 @@ namespace App\Parsing;
 
 use InvalidArgumentException;
 
-class OptionDefinition
+final readonly class OptionDefinition
 {
     public function __construct(
         public string $name,
@@ -52,11 +52,12 @@ class OptionDefinition
         }
 
         $first = $value[0];
-        $last = substr($value, -1);
 
         if ($first !== '"' && $first !== "'") {
             return $value;
         }
+
+        $last = substr($value, -1);
 
         if ($first !== $last) {
             return $value;

--- a/app/Parsing/ParseResult.php
+++ b/app/Parsing/ParseResult.php
@@ -4,7 +4,7 @@ namespace App\Parsing;
 
 use RuntimeException;
 
-class ParseResult
+final readonly class ParseResult
 {
     public function __construct(
         /** @var array<string, ServerDefinition> */
@@ -49,37 +49,37 @@ class ParseResult
     {
         $macro = $this->getMacro($name);
 
-        if ($macro !== null) {
-            if (isset($visited[$name])) {
-                $cycle = implode(' -> ', [...array_keys($visited), $name]);
+        if ($macro === null) {
+            $task = $this->getTask($name);
 
-                throw new RuntimeException("Macro \"{$name}\" forms a cycle: {$cycle}");
+            if ($task === null) {
+                return [];
             }
 
-            $visited[$name] = true;
-
-            $tasks = [];
-
-            foreach ($macro->tasks as $childName) {
-                if (! isset($this->macros[$childName]) && ! isset($this->tasks[$childName])) {
-                    throw new RuntimeException(
-                        "Macro \"{$name}\" references unknown target \"{$childName}\"."
-                    );
-                }
-
-                $tasks[] = $this->resolveTasksForTargetRecursive($childName, $visited);
-            }
-
-            return array_merge([], ...$tasks);
-        }
-
-        $task = $this->getTask($name);
-
-        if ($task !== null) {
             return [$task];
         }
 
-        return [];
+        if (isset($visited[$name])) {
+            $cycle = implode(' -> ', [...array_keys($visited), $name]);
+
+            throw new RuntimeException("Macro \"{$name}\" forms a cycle: {$cycle}");
+        }
+
+        $visited[$name] = true;
+
+        $tasks = [];
+
+        foreach ($macro->tasks as $childName) {
+            if (! isset($this->macros[$childName]) && ! isset($this->tasks[$childName])) {
+                throw new RuntimeException(
+                    "Macro \"{$name}\" references unknown target \"{$childName}\"."
+                );
+            }
+
+            $tasks[] = $this->resolveTasksForTargetRecursive($childName, $visited);
+        }
+
+        return array_merge([], ...$tasks);
     }
 
     /** @return array<HookDefinition> */

--- a/app/Parsing/ServerDefinition.php
+++ b/app/Parsing/ServerDefinition.php
@@ -2,19 +2,22 @@
 
 namespace App\Parsing;
 
-class ServerDefinition
+final class ServerDefinition
 {
+    protected const LOCAL_HOSTS = ['127.0.0.1', 'localhost', 'local'];
+
     /** @var array<string> */
     public readonly array $hosts;
 
+    /**
+     * @param  string|array<string>  $host
+     */
     public function __construct(
-        public string $name,
+        public readonly string $name,
         string|array $host,
     ) {
         $this->hosts = is_array($host) ? array_values($host) : [$host];
     }
-
-    protected const LOCAL_HOSTS = ['127.0.0.1', 'localhost', 'local'];
 
     public function isLocal(): bool
     {

--- a/app/Parsing/TaskDefinition.php
+++ b/app/Parsing/TaskDefinition.php
@@ -2,7 +2,7 @@
 
 namespace App\Parsing;
 
-class TaskDefinition
+final readonly class TaskDefinition
 {
     public function __construct(
         public string $name,
@@ -25,10 +25,10 @@ class TaskDefinition
 
     public function displayNameWithEmoji(): string
     {
-        if ($this->emoji !== null) {
-            return "{$this->emoji}  {$this->displayName()}";
+        if ($this->emoji === null) {
+            return $this->displayName();
         }
 
-        return $this->displayName();
+        return "{$this->emoji}  {$this->displayName()}";
     }
 }

--- a/app/Ssh/SshConfigFile.php
+++ b/app/Ssh/SshConfigFile.php
@@ -68,16 +68,12 @@ class SshConfigFile
     /** @param array<string, string> $group */
     protected function groupMatchesHostname(array $group, string $hostname): bool
     {
-        if (isset($group['host'])) {
-            if ($group['host'] === $hostname) {
-                return true;
-            }
+        if (($group['host'] ?? null) === $hostname) {
+            return true;
         }
 
-        if (isset($group['hostname'])) {
-            if ($group['hostname'] === $hostname) {
-                return true;
-            }
+        if (($group['hostname'] ?? null) === $hostname) {
+            return true;
         }
 
         return false;

--- a/app/Updater/SelfUpdater.php
+++ b/app/Updater/SelfUpdater.php
@@ -40,7 +40,7 @@ class SelfUpdater
             return UpdateResult::failed('Downloaded phar is suspiciously small, refusing to replace.');
         }
 
-        $tempPath = $pharPath.'.new';
+        $tempPath = "{$pharPath}.new";
 
         if (@file_put_contents($tempPath, $contents) === false) {
             return UpdateResult::failed("Failed to write temporary file at {$tempPath}.");

--- a/app/Updater/UpdateCachePath.php
+++ b/app/Updater/UpdateCachePath.php
@@ -8,8 +8,10 @@ class UpdateCachePath
     {
         $xdgCacheHome = getenv('XDG_CACHE_HOME');
 
-        if (is_string($xdgCacheHome) && $xdgCacheHome !== '') {
-            return $xdgCacheHome.'/scotty';
+        if (is_string($xdgCacheHome)) {
+            if ($xdgCacheHome !== '') {
+                return "{$xdgCacheHome}/scotty";
+            }
         }
 
         $home = getenv('HOME');
@@ -22,6 +24,6 @@ class UpdateCachePath
             return sys_get_temp_dir().'/scotty';
         }
 
-        return $home.'/.cache/scotty';
+        return "{$home}/.cache/scotty";
     }
 }

--- a/app/Updater/UpdateChecker.php
+++ b/app/Updater/UpdateChecker.php
@@ -116,6 +116,6 @@ class UpdateChecker
 
     protected function cacheFile(): string
     {
-        return $this->cacheDirectory.'/update-check';
+        return "{$this->cacheDirectory}/update-check";
     }
 }


### PR DESCRIPTION
## Summary

Mechanical pass over `app/` to apply Spatie PHP/Laravel conventions. No behavior changes (127 tests still pass, phpstan clean, pint clean).

### Notable refactors

- `RunCommand` — extracted `detectSystemTimezone()` and `resolveOptionValue()`, dropped inline `\DateTime`/`\DateTimeZone`, tightened `in_array` strict mode.
- `DoctorCommand` — collapsed five near-identical `extract*Version()` methods into one parameterized helper.
- `SshCommand` — flattened nested if/else host resolution into `buildHostOptions`/`resolveHostByServerName`/`promptForRemoteHost`.
- `TasksCommand` — extracted `renderMacros()`/`renderTasks()` from `handle()`.
- `BashParser` — inverted guard clauses across the parsers, removed redundant regex check, dropped `\\$char`-style nested quote-state branches.
- DTOs (`HookDefinition`, `MacroDefinition`, `OptionDefinition`, `ParseResult`, `ServerDefinition`, `TaskDefinition`, `NotificationDefinition`) — marked `final readonly` where applicable.
- `Compiler.php` — inlined the thin `compileRegularEchos` pass-through into `compileEchos`.
- `SshConfigFile` — simplified `groupMatchesHostname` from `isset` + equality nesting to `?? null` ternary guards.
- `TaskRunner` — replaced an `if/else` in `resolveServerMap()` with a `continue` guard.

### Style/typing

- `?Type` over `Type|null`.
- Constructor property promotion where everything fits.
- String interpolation over concatenation.
- Imports added; inline `\Foo\Bar` removed.
- Strict `in_array` calls.
- Compound `&&` conditions split into nested `if` per Spatie style.

### Pre-existing issue not fixed here

`InitCommand::bladeTemplate()` returns a literal `'%s'` placeholder that's never substituted, so the user's host doesn't get written into the generated `Scotty.blade.php`. The current test only checks that the file exists, so this regression has been silent. Worth a follow-up PR.

### Verification

- `vendor/bin/pest` — 127 passed (287 assertions)
- `vendor/bin/phpstan analyse` — no errors
- `vendor/bin/pint --test` — pass