### PR TITLE
Fix init blade template host placeholder

### DIFF
--- a/app/Commands/InitCommand.php
+++ b/app/Commands/InitCommand.php
@@ -76,12 +76,14 @@ class InitCommand extends Command
 
     protected function bladeTemplate(string $host): string
     {
-        return <<<'BLADE'
-        @servers(['local' => '127.0.0.1', 'remote' => '%s'])
+        return <<<BLADE
+        @servers(['local' => '127.0.0.1', 'remote' => '{$host}'])
+
+        @option('branch=main')
 
         @task('deploy', ['on' => 'remote'])
             cd /home/forge/myapp
-            git pull origin {{ $branch }}
+            git pull origin {{ \$branch }}
             php artisan migrate --force
         @endtask
         BLADE;

--- a/tests/Feature/InitCommandTest.php
+++ b/tests/Feature/InitCommandTest.php
@@ -41,6 +41,13 @@ it('creates a Scotty.blade.php file when blade format selected', function () {
         ->assertExitCode(0);
 
     expect(file_exists($this->tempDir.'/Scotty.blade.php'))->toBeTrue();
+
+    $content = file_get_contents($this->tempDir.'/Scotty.blade.php');
+
+    expect($content)->toContain("'remote' => 'forge@example.com'")
+        ->and($content)->toContain("@option('branch=main')")
+        ->and($content)->toContain('git pull origin {{ $branch }}')
+        ->and($content)->not->toContain('%s');
 });
 
 it('fails when file already exists', function () {


### PR DESCRIPTION
## Summary

`InitCommand::bladeTemplate()` was a nowdoc with a literal `'%s'` that never got substituted, so the host the user typed during `scotty init` was silently dropped from the generated `Scotty.blade.php`. The existing test only checked the file existed, so it slipped through.

While here, also added `@option('branch=main')` since the template references `{{ $branch }}` and would have failed at runtime without it.

## Changes

- Switched the blade template to a heredoc so `{$host}` interpolates; escaped `\$branch` to keep the literal blade syntax.
- Added `@option('branch=main')` so the generated file actually runs out of the box.
- Tightened the blade test to assert the host appears, the option declaration is there, the blade `{{ $branch }}` is preserved, and no leftover `%s` remains.