### PR TITLE
Treat macro-to-macro references as valid in doctor

### DIFF
--- a/app/Commands/DoctorCommand.php
+++ b/app/Commands/DoctorCommand.php
@@ -147,7 +147,7 @@ class DoctorCommand extends Command
             return;
         }
 
-        $this->writeSuccess('All macro tasks exist');
+        $this->writeSuccess('All macro references resolve');
     }
 
     /** @return array<string> */
@@ -156,12 +156,16 @@ class DoctorCommand extends Command
         $invalid = [];
 
         foreach ($config->macros as $macro) {
-            foreach ($macro->tasks as $taskName) {
-                if ($config->getTask($taskName) !== null) {
+            foreach ($macro->tasks as $targetName) {
+                if ($config->getTask($targetName) !== null) {
                     continue;
                 }
 
-                $invalid[] = "Macro \"{$macro->name}\" references undefined task \"{$taskName}\"";
+                if ($config->getMacro($targetName) !== null) {
+                    continue;
+                }
+
+                $invalid[] = "Macro \"{$macro->name}\" references undefined task or macro \"{$targetName}\"";
             }
         }
 

--- a/tests/Feature/DoctorCommandTest.php
+++ b/tests/Feature/DoctorCommandTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+
+beforeEach(function () {
+    $this->fixturePath = realpath(__DIR__.'/../fixtures');
+});
+
+it('does not flag macros that reference other macros as undefined', function () {
+    Artisan::call('doctor', [
+        '--conf' => $this->fixturePath.'/nested-macros.sh',
+    ]);
+
+    $output = Artisan::output();
+
+    expect($output)
+        ->toContain('All macro references resolve')
+        ->not->toContain('undefined task or macro');
+});

--- a/tests/fixtures/nested-macros.sh
+++ b/tests/fixtures/nested-macros.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env scotty
+
+# @servers local=127.0.0.1
+# @macro story_1 task_1
+# @macro story_2 task_2 story_1
+
+# @task on:local
+task_1() {
+    echo "task 1"
+}
+
+# @task on:local
+task_2() {
+    echo "task 2"
+}


### PR DESCRIPTION
## Summary

The `doctor` command's macro reference check only looked up target names in the task list. When a macro referenced another macro (already supported by the runner since #5), `doctor` incorrectly reported it as an undefined task.

This change accepts macros as valid targets too and updates both the failure and success messages so they no longer imply that only tasks are valid.

Fixes #15