### PR TITLE
Print self-update success before replacing the running phar

### DIFF
--- a/app/Commands/SelfUpdateCommand.php
+++ b/app/Commands/SelfUpdateCommand.php
@@ -50,11 +50,15 @@ class SelfUpdateCommand extends Command
 
         info("Updating Scotty from {$currentVersion} to {$targetVersion}...");
 
-        $result = (new SelfUpdater)->update($targetVersion, $pharPath);
+        $result = (new SelfUpdater)->update(
+            $targetVersion,
+            $pharPath,
+            beforeCommit: function () use ($targetVersion): void {
+                info("Successfully updated to {$targetVersion}.");
+            },
+        );
 
         if ($result->succeeded) {
-            info("Updated to {$targetVersion}.");
-
             return 0;
         }
 

--- a/app/Updater/SelfUpdater.php
+++ b/app/Updater/SelfUpdater.php
@@ -18,7 +18,10 @@ class SelfUpdater
         $this->downloader = $downloader ?? fn (string $url): ?string => $this->defaultDownloader($url);
     }
 
-    public function update(string $version, string $pharPath): UpdateResult
+    /**
+     * @param  ?callable(): void  $beforeCommit  Invoked once the new phar is on disk and validated, immediately before it replaces the running phar. Use this to flush user-facing messages while the running phar is still intact.
+     */
+    public function update(string $version, string $pharPath, ?callable $beforeCommit = null): UpdateResult
     {
         if (! is_writable(dirname($pharPath))) {
             return UpdateResult::failed("Cannot write to {$pharPath}. Re-run with sudo.");
@@ -47,6 +50,10 @@ class SelfUpdater
         }
 
         @chmod($tempPath, 0755);
+
+        if ($beforeCommit !== null) {
+            $beforeCommit();
+        }
 
         if (! @rename($tempPath, $pharPath)) {
             @unlink($tempPath);

--- a/tests/Unit/SelfUpdaterTest.php
+++ b/tests/Unit/SelfUpdaterTest.php
@@ -52,6 +52,28 @@ it('substitutes the version into the download URL template', function () {
     expect($receivedUrl)->toBe('https://example.test/scotty-1.4.0.phar');
 });
 
+it('invokes the beforeCommit callback while the original phar is still in place', function () {
+    $payload = str_repeat('NEW', SelfUpdater::MIN_PHAR_SIZE_BYTES);
+
+    $updater = new SelfUpdater(
+        downloader: fn (): string => $payload,
+    );
+
+    $contentsAtCallback = null;
+
+    $result = $updater->update(
+        '1.4.0',
+        $this->pharPath,
+        beforeCommit: function () use (&$contentsAtCallback) {
+            $contentsAtCallback = file_get_contents($this->pharPath);
+        },
+    );
+
+    expect($result->succeeded)->toBeTrue()
+        ->and($contentsAtCallback)->toBe(str_repeat('OLD', 1024))
+        ->and(file_get_contents($this->pharPath))->toBe($payload);
+});
+
 it('returns failure when the download is suspiciously small', function () {
     $updater = new SelfUpdater(
         downloader: fn (): string => 'tiny',


### PR DESCRIPTION
## Summary

After a self-update, users only saw "Updating Scotty from X to Y..." with nothing after it. The follow-up "Updated to Y." line never made it to the terminal because by the time it ran, the phar containing the running code had already been replaced, and PHP's phar wrapper can no longer reliably load any not-yet-loaded class from a file whose contents have changed mid-execution.

The fix introduces a `beforeCommit` hook in `SelfUpdater::update()` that fires after the new phar is downloaded and validated but before the atomic rename. The command uses it to emit the success line while the running phar is still intact.