### PR TITLE
Fix local shell injection via @servers host in doctor command (CWE-78)

### DIFF
--- a/app/Commands/DoctorCommand.php
+++ b/app/Commands/DoctorCommand.php
@@ -206,13 +206,26 @@ class DoctorCommand extends Command
         }
     }
 
+    /**
+     * Build the ssh argv for the given host and remote command.
+     *
+     * Passed to Process as an array (not a shell command string), so each
+     * element — including the host, which comes from the untrusted @servers
+     * directive — is executed as a single literal argument. The host can
+     * never be interpreted by a local shell, however it is composed.
+     *
+     * @return array<string>
+     */
+    protected function buildSshCommand(string $host, string $remoteCommand): array
+    {
+        return ['ssh', '-o', 'ConnectTimeout=5', '-o', 'BatchMode=yes', $host, $remoteCommand];
+    }
+
     protected function checkSshConnectivity(string $name, string $host): bool
     {
         $startTime = microtime(true);
 
-        $command = "ssh -o ConnectTimeout=5 -o BatchMode=yes {$host} 'echo ok'";
-
-        $process = Process::fromShellCommandline($command);
+        $process = new Process($this->buildSshCommand($host, 'echo ok'));
         $process->setTimeout(self::SSH_TIMEOUT);
 
         try {
@@ -251,9 +264,7 @@ class DoctorCommand extends Command
             'git --version 2>/dev/null',
         ]);
 
-        $command = "ssh -o ConnectTimeout=5 -o BatchMode=yes {$host} '{$toolCheckScript}'";
-
-        $process = Process::fromShellCommandline($command);
+        $process = new Process($this->buildSshCommand($host, $toolCheckScript));
         $process->setTimeout(self::REMOTE_TOOLS_TIMEOUT);
 
         try {

--- a/tests/Unit/DoctorCommandSshTest.php
+++ b/tests/Unit/DoctorCommandSshTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Commands\DoctorCommand;
+
+function buildDoctorSshCommand(string $host, string $remoteCommand): array
+{
+    $method = new ReflectionMethod(DoctorCommand::class, 'buildSshCommand');
+
+    return $method->invoke(new DoctorCommand, $host, $remoteCommand);
+}
+
+it('builds the ssh command as an argv array, not a shell string', function () {
+    $argv = buildDoctorSshCommand('forge@1.1.1.1', 'echo ok');
+
+    expect($argv)->toBeArray()
+        ->and($argv)->toBe([
+            'ssh', '-o', 'ConnectTimeout=5', '-o', 'BatchMode=yes', 'forge@1.1.1.1', 'echo ok',
+        ]);
+});
+
+it('keeps a host containing shell metacharacters as a single literal argv element', function () {
+    // The exact payload style from a real @servers host injection report: `;` chains a
+    // second local command, and ${IFS} stands in for a space so it survives the
+    // whitespace-delimited @servers parser while still being shell-meaningful.
+    $maliciousHost = 'evil.example;touch${IFS}/tmp/pwned';
+
+    $argv = buildDoctorSshCommand($maliciousHost, 'echo ok');
+
+    expect($argv)->toBe([
+        'ssh', '-o', 'ConnectTimeout=5', '-o', 'BatchMode=yes', $maliciousHost, 'echo ok',
+    ]);
+
+    // The host must appear as exactly one, unmodified argv element - never merged
+    // with any other token into a combined string. That merging is what let it
+    // reach a local shell in the first place.
+    $matches = array_filter($argv, fn (string $part): bool => str_contains($part, 'evil.example'));
+
+    expect($matches)->toHaveCount(1)
+        ->and(array_values($matches)[0])->toBe($maliciousHost);
+});
+
+it('keeps the host and remote command as separate argv elements for the tool-check command', function () {
+    $maliciousHost = 'evil.example;touch${IFS}/tmp/pwned';
+    $remoteCommand = 'php -v; composer --version';
+
+    $argv = buildDoctorSshCommand($maliciousHost, $remoteCommand);
+
+    expect($argv)->toBe([
+        'ssh', '-o', 'ConnectTimeout=5', '-o', 'BatchMode=yes', $maliciousHost, $remoteCommand,
+    ]);
+});


### PR DESCRIPTION
Fixes #20

## Summary
`DoctorCommand::checkSshConnectivity()` and `checkRemoteTools()` build the `ssh` invocation by interpolating the host from the `@servers` directive directly into a shell command string:

```php
$command = "ssh -o ConnectTimeout=5 -o BatchMode=yes {$host} 'echo ok'";
$process = Process::fromShellCommandline($command);
```

and execute it via `Process::fromShellCommandline()`, which runs the string through the local shell. Since `$host` comes straight from a project's Scotty file (an `@servers` directive an attacker could control via a crafted repository), shell metacharacters in the host are interpreted by the local shell *before* `ssh` ever runs — e.g. a host of `evil.example;touch /tmp/pwned` executes `touch /tmp/pwned` locally when a victim runs `scotty doctor`.

## Fix
Extracted the command construction into `buildSshCommand()`, which returns an argv array, and pass that to `Process` in array form instead of building a shell string:

```php
protected function buildSshCommand(string $host, string $remoteCommand): array
{
    return ['ssh', '-o', 'ConnectTimeout=5', '-o', 'BatchMode=yes', $host, $remoteCommand];
}
```

Symfony's `Process` never invokes a local shell when given an array — each element (including the host) is passed as a single literal argument to `exec()`. Shell metacharacters in the host can no longer be interpreted locally, regardless of their content.

Both call sites (`checkSshConnectivity()` and `checkRemoteTools()`) now go through this same helper.

## Testing
Added `tests/Unit/DoctorCommandSshTest.php`, following this repo's existing convention (see `SshCommandBuilderTest.php`) of testing the constructed command deterministically rather than spawning real `ssh` processes (which would add flaky network/CI dependencies that don't exist today — no current test exercises `checkSshConnectivity` at all).

The tests assert:
- The command is built as an argv array, not a shell string.
- A host containing shell metacharacters (using the exact `evil.example;touch${IFS}/tmp/pwned`-style payload from the report) survives as a single, unmodified argv element — never merged with any other token into a combined string.
- Host and remote command stay as separate argv elements for the tool-check path too.

I confirmed the test method is genuinely new (not just re-testing existing behavior) by running it against the pre-fix code: `buildSshCommand()` doesn't exist there, so the test fails with `ReflectionException` as expected, then passes once the fix is applied.

Full suite: `phpstan analyse` and `pint --test` are both clean. `vendor/bin/pest` has 23 pre-existing failures on unmodified `main` too (`DateInvalidTimeZoneException` in `RunCommandTest`, plus `SshConfigFileTest` parsing failures) — confirmed via `git stash` that they're present without this change as well, and unrelated to `DoctorCommand`/`SshCommandBuilder`. All tests touching the changed files pass.

## Checklist
- [x] Added/updated tests
- [x] Existing tests pass (aside from pre-existing, unrelated environment failures noted above)
- [x] Static analysis (PHPStan) passes
- [x] Code style (Pint) passes